### PR TITLE
Expand use of parallel queries for metrics

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -938,14 +938,13 @@ getMetricDataFromIdsSets = function (url, periods, metricGroupIdsByLabelSets) {
   var elements = data.responses.length;
 
   var valueSets = [];
+  var count = 0;
   for (var idx = 0; idx < metricGroupIdsByLabelSets.length; idx++) {
     thisSetElements = elements / metricGroupIdsByLabelSets.length;
-    //valueSets[idx] = [];
     var valuesByLabel = {};
     Object.keys(metricGroupIdsByLabelSets[idx]).forEach(function(label) {
-    //metricGroupIdsByLabelSets[idx].forEach(label => {
       valuesByLabel[label] = [];
-      thisLabelElements = thisSetElements / metricGroupIdsByLabelSets[idx][label].length;
+      thisLabelElements = metricGroupIdsByLabelSets[idx][label].length;
       var metricIds = metricGroupIdsByLabelSets[idx][label];
       var values = [];
       var begin = Number(periods[idx].begin);
@@ -954,11 +953,10 @@ getMetricDataFromIdsSets = function (url, periods, metricGroupIdsByLabelSets) {
       var duration = Math.floor((end - begin) / resolution);
       var thisBegin = begin;
       var thisEnd = begin + duration;
-      var count = 0;
       var subCount = 0;
       //var elements = data.responses.length / metricGroupIdsByLabelSets.length;
       var numMetricIds = metricIds.length;
-      while (count < thisLabelElements) {
+      while (subCount < thisLabelElements) {
         var timeWindowDuration = thisEnd - thisBegin + 1;
         var totalWeightTimesMetrics = timeWindowDuration * numMetricIds;
         subCount++;
@@ -1037,7 +1035,7 @@ getMetricDataFromIdsSets = function (url, periods, metricGroupIdsByLabelSets) {
         dataSample.value = result;
         values.push(dataSample);
 
-        count += 4;
+        count += 4; // Bumps count to the next set of responses
         thisBegin = thisEnd + 1;
         thisEnd += duration + 1;
         if (thisEnd > end) {
@@ -1049,15 +1047,10 @@ getMetricDataFromIdsSets = function (url, periods, metricGroupIdsByLabelSets) {
           //thisEnd = end;
         //}
       }
-      //console.log("values for set " + idx + " for label [" + label + "]:\n" + JSON.stringify(values));
-      valuesByLabel[label].push(values);
-      //console.log("valuesByLabel[" + label + "] for set " + idx + ":\n" + JSON.stringify(valuesByLabel[label]));
+      valuesByLabel[label] = values;
     });
-    //valueSets.push(valuesByLabel);
     valueSets[idx] = valuesByLabel;
-    //console.log("valuesSets[" + idx + "]:\n" + JSON.stringify(valueSets[idx]));
   }
-  //console.log("valueSets:\n" + JSON.stringify(valueSets));
   return valueSets;
 };
 exports.getMetricDataFromIds = getMetricDataFromIds;


### PR DESCRIPTION
- Before this commit: finding a value for a metric from a single time range involved 4 queries
  which are done by getMetricDataFromIds().  These 4 queries are what's needed to compute a
  weighted average.  This introduced the first use of _msearch, where the 4 queries were
  combined into a NDJSON and submitted together.
- Since getMetricDataFromIds() also supported not just 1, but many values (over time) for
  a single time range, these 4 queries could be multiplied by N to get a time-series with N samples.
- Also, getMetricDataFromIds() supported breaking-out a metric, where a value (or time-series)
  was generated for different values of the metric's name-format (like per-client Gbps, or per-job
  iops).
- All of these functions had been made more efficient by using the _search and NDJSON
- This commit expands on that concept and allows the user to query for multiple time-ranges.
  This gives us the ability to query for mulitple samples at the same time.
  This cuts the query time up to by 50% depending on the number of samples.