### PR TITLE
templates/metric_desc.base: remove 'time_window' from allowable names

### DIFF
--- a/templates/metric_desc.base
+++ b/templates/metric_desc.base
@@ -47,8 +47,7 @@
                   "protocol": { "type": "keyword" },
                   "action": { "type": "keyword" },
                   "cstype": { "type": "keyword" },
-                  "csid": { "type": "keyword" },
-                  "time_window": { "type": "keyword" }
+                  "csid": { "type": "keyword" }
                 }
               }
             }


### PR DESCRIPTION
- This turned out to be an incorrect usage of this information.