### PR TITLE
Always use "value" in metric_data, just provide look-up in metric_desc

### DIFF
--- a/templates/metric_desc.base
+++ b/templates/metric_desc.base
@@ -49,6 +49,13 @@
                   "cstype": { "type": "keyword" },
                   "csid": { "type": "keyword" }
                 }
+              },
+              "value-format": { "type": "keyword" },
+              "values": {
+                "properties": {
+                  "pass": { "type": "keyword" },
+                  "fail": { "type": "keyword" }
+                }
               }
             }
           },


### PR DESCRIPTION
-We had dicsussed (a while back) the ability to store a non-number
 for a metric.  THis would be needed for things like pass/fail.  Instead
 of adding another field to metric_desc, I have an adding an optional
 values-format in metric_desc.  We can add entries in values-format
 that tell us what a number means, like 0 = fail and 1 = pass.
 If this does not work well, we'll try something else.