### PR TITLE
add counter as a keyword

### DIFF
--- a/templates/metric_desc.base
+++ b/templates/metric_desc.base
@@ -49,6 +49,7 @@
                   "cpu": { "type": "keyword" },
                   "irq": { "type": "keyword" },
                   "desc": { "type": "keyword" },
+                  "counter": { "type": "keyword" },
                   "cstype": { "type": "keyword" },
                   "csid": { "type": "keyword" }
                 }


### PR DESCRIPTION
I'm not sure if this would cause a collision with the type counter in CDM. but I think it would be useful for application reported metrics, the ovs-dpctl memory/show looks like its just a counter for the handlers etc. not worries if this doesn't fit