### PR TITLE
Metric queries always need a run id or a period id

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -1242,6 +1242,7 @@ getMetricIdsFromTerms = function (url, runId, periId, terms_string) {
   }
   var resp = esRequest(url, "metric_desc/_doc/_search", q);
   var data = JSON.parse(resp.getBody());
+  // hits.total.value is not reliable, so also check array length 
   if (data.hits.total.value >= bigQuerySize || data.hits.hits.length >= bigQuerySize) {
     console.log("ERROR: hits from returned query exceeded max size of " + bigQuerySize);
     return;


### PR DESCRIPTION
- A run ID must be used for getMetricIdsFromTerms query.  If not, the number of hits returned may exceed 262144, and not all the relevant IDs may be included.