### PR TITLE
Fix query size and add check

### DIFF
--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -33,7 +33,6 @@ program
 metric_data = cdm.getMetricData(program.url, program.run, program.period, program.source, program.type,
                                 program.begin, program.end, program.resolution, program.breakout, program.filter);
 
-console.log("metric_data:\n" + JSON.stringify(metric_data, null, 2));
 if (Object.keys(metric_data.values).length == 0) {
     console.log("There were no metrics found, exiting");
     process.exit(1);


### PR DESCRIPTION
- Some queries did not have a right "size", most critically when the two
  getMetricDataFromId[Sets] were consolidated into 1.
- Returned data is now checked to see if hits.size and hits.hits.length
  matches, in the general-purpose mSearch function.