### PR TITLE
add concurrency limitations to the crucible-ci workflow

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -10,6 +10,10 @@ on:
     - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-job-matrix-parameters:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- create a concurrency group per pull request

- when a new execution of the workflow is queued for the same concurrency group as an existing execution, cancel the prior executions

- this avoids inefficient workflow execution via wasted runs