### PR TITLE
Add REST API server wrapper script

### DIFF
--- a/queries/cdmq/start-server.sh
+++ b/queries/cdmq/start-server.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+
+# This script starts the CommonDataModel REST API server
+# which provides metric data queries via HTTP endpoints
+
+project_dir=$(dirname `readlink -e $0`)
+pushd "$project_dir" >/dev/null
+node ./server.js "$@"
+rc=$?
+popd >/dev/null
+exit $rc


### PR DESCRIPTION
## Summary
Add a bash wrapper script `start-server.sh` to launch the Node.js CDM REST API server (`server.js`). This script enables the crucible project to start the CDM server as a companion service to OpenSearch.

## Changes
- Add `queries/cdmq/start-server.sh` - wrapper script to execute `server.js` in the correct directory context

## Purpose
The wrapper script:
- Changes to the `queries/cdmq` directory before executing `server.js`
- Ensures Node.js can properly resolve CDM module dependencies
- Follows the same pattern as existing scripts like `get-metric-data.sh`
- Accepts command-line arguments for OpenSearch connection details (`--host`, `--userpass`, `--ver`)

## Integration
This script is called by the crucible project's `start_cdm_server()` function to launch the CDM REST API server on port 3000 whenever OpenSearch is started.

## Related Issue
Addresses #144 (Write a JS server to handle metric data requests and other CDM queries via REST API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)