### PR TITLE
Refactor query scripts to use CDM API server

### DIFF
--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -76,7 +76,46 @@ async function fetchMetricData(serverUrl, params) {
   });
 }
 
+function list_hosts(val) {
+  // Parse comma-separated host values
+  return val.split(',');
+}
+
+function save_host(host) {
+  if (!program.instances) {
+    program.instances = [];
+  }
+  var host_info = { host: host, header: { 'Content-Type': 'application/json' } };
+  program.instances.push(host_info);
+}
+
+function save_userpass(userpass) {
+  if (!program.instances || program.instances.length == 0) {
+    console.log('You must specify a --host before a --userpass');
+    process.exit(1);
+  }
+  program.instances[program.instances.length - 1]['header'] = {
+    'Content-Type': 'application/json',
+    Authorization: 'Basic ' + btoa(userpass)
+  };
+}
+
+function save_ver(ver) {
+  if (!program.instances || program.instances.length == 0) {
+    console.log('You must specify a --host before a --ver');
+    process.exit(1);
+  }
+  if (/^v[7|8|9]dev$/.exec(ver)) {
+    program.instances[program.instances.length - 1]['ver'] = ver;
+  } else {
+    console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);
+    process.exit(1);
+  }
+}
+
 async function main() {
+  program.instances = [];
+
   program
     .version('0.1.0')
     .option(
@@ -84,6 +123,9 @@ async function main() {
       'The URL of the metric data API server (e.g., http://localhost:3000/api/metric-data)',
       'http://localhost:3000/api/metric-data'
     )
+    .option('--host <host[:port]>', 'The host and optional port of the OpenSearch instance (passed to server)', save_host)
+    .option('--userpass <user:pass>', 'The user and password for the most recent --host (passed to server)', save_userpass)
+    .option('--ver <v7dev|v8dev|v9dev>', 'The Common Data Model version to use for the most recent --host (passed to server)', save_ver)
     .option('--run <uuid>', 'The UUID from the run')
     .option('--period <uuid>', 'The UUID from the benchmark-iteration-sample-period')
     .option('--source <name>', 'The metric source, like a tool or benchmark name (sar, fio)')
@@ -150,7 +192,8 @@ async function main() {
     end: program.end,
     resolution: program.resolution,
     breakout: program.breakout, // Send as array to preserve complex breakout syntax
-    filter: program.filter
+    filter: program.filter,
+    instances: program.instances.length > 0 ? program.instances : undefined // Pass instances to server if provided
   };
 
   // Fetch metric data from the API

--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -9,10 +9,10 @@
 //
 //# vim: autoindent tabstop=2 shiftwidth=2 expandtab softtabstop=2 filetype=javascript
 
-var cdm = require('./cdm');
 var program = require('commander');
 var sprintf = require('sprintf-js').sprintf;
-var instances = []; // opensearch instances
+const http = require('http');
+const https = require('https');
 
 function list(val) {
   // Commas separate breakout fields. Multiple values for a field use '+':
@@ -20,41 +20,70 @@ function list(val) {
   return val.split(',');
 }
 
-function save_host(host) {
-  var host_info = { host: host, header: { 'Content-Type': 'application/json' } };
-  instances.push(host_info);
-}
+/**
+ * Make an HTTP POST request to the metric data API
+ */
+async function fetchMetricData(serverUrl, params) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(serverUrl);
+    const isHttps = url.protocol === 'https:';
+    const client = isHttps ? https : http;
 
-function save_userpass(userpass) {
-  if (instances.length == 0) {
-    console.log('You must specify a --host before a --userpass');
-    process.exit(1);
-  }
-  instances[instances.length - 1]['header'] = {
-    'Content-Type': 'application/json',
-    Authorization: 'Basic ' + btoa(userpass)
-  };
-}
+    const postData = JSON.stringify(params);
 
-function save_ver(ver) {
-  if (instances.length == 0) {
-    console.log('You must specify a --host before a --ver');
-    process.exit(1);
-  }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
-    instances[instances.length - 1]['ver'] = ver;
-  } else {
-    console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);
-    process.exit(1);
-  }
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(postData)
+      }
+    };
+
+    const req = client.request(options, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          try {
+            resolve(JSON.parse(data));
+          } catch (e) {
+            reject(new Error(`Failed to parse response: ${e.message}`));
+          }
+        } else {
+          try {
+            const errorData = JSON.parse(data);
+            reject(new Error(errorData.error || `HTTP ${res.statusCode}: ${data}`));
+          } catch (e) {
+            reject(new Error(`HTTP ${res.statusCode}: ${data}`));
+          }
+        }
+      });
+    });
+
+    req.on('error', (error) => {
+      reject(new Error(`Failed to connect to server at ${serverUrl}: ${error.message}`));
+    });
+
+    req.write(postData);
+    req.end();
+  });
 }
 
 async function main() {
   program
     .version('0.1.0')
-    .option('--host <host[:port]>', 'The host and optional port of the OpenSearch instance', save_host)
-    .option('--userpass <user:pass>', 'The user and password for the most recent --host', save_userpass)
-    .option('--ver <v7dev|v8dev|v9dev>', 'The Common Data Model version to use for the most recent --host', save_ver)
+    .option(
+      '--server-url <url>',
+      'The URL of the metric data API server (e.g., http://localhost:3000/api/metric-data)',
+      'http://localhost:3000/api/metric-data'
+    )
     .option('--run <uuid>', 'The UUID from the run')
     .option('--period <uuid>', 'The UUID from the benchmark-iteration-sample-period')
     .option('--source <name>', 'The metric source, like a tool or benchmark name (sar, fio)')
@@ -106,44 +135,13 @@ async function main() {
     )
     .parse(process.argv);
 
-  // If the user does not specify any hosts, assume localhost:9200 is used
-  if (instances.length == 0) {
-    save_host('localhost:9200');
-  }
-
-  getInstancesInfo(instances);
-  var yearDotMonth;
-  var instance;
-  if (program.run != null) {
-    instance = await findInstanceFromRun(instances, program.run);
-    if (instance == null) {
-      console.log(
-        'Could not find run ID ' +
-          program.period +
-          ' in any of the Opensearch instances:\n' +
-          JSON.stringify(instances, null, 2)
-      );
-      process.exit(1);
-    }
-  } else if (program.period != null) {
-    instance = await findInstanceFromPeriod(instances, program.period);
-    if (instance == null) {
-      console.log(
-        'Could not find period ID ' +
-          program.period +
-          ' in any of the Opensearch instances:\n' +
-          JSON.stringify(instances, null, 2)
-      );
-      process.exit(1);
-    }
-    // We don't yet know the yearDotMonth, so use wildcard to query all period indices
-    program.run = await getRunFromPeriod(instance, program.period, '@*');
-  } else {
+  if (program.run == null && program.period == null) {
     console.log('Exiting because neither a period nor a run ID were provided');
     process.exit(1);
   }
-  var yearDotMonth = await findYearDotMonthFromRun(instance, program.run);
-  var set = {
+
+  // Prepare the request parameters for the API
+  const apiParams = {
     run: program.run,
     period: program.period,
     source: program.source,
@@ -151,22 +149,25 @@ async function main() {
     begin: program.begin,
     end: program.end,
     resolution: program.resolution,
-    breakout: program.breakout,
+    breakout: program.breakout, // Send as array to preserve complex breakout syntax
     filter: program.filter
   };
-  var resp = (metric_data = await cdm.getMetricDataSets(instance, [set], yearDotMonth));
-  if (resp['ret-code'] != 0) {
-    console.log('Exiting: ' + resp['ret-msg']);
+
+  // Fetch metric data from the API
+  let metric_data;
+  try {
+    metric_data = await fetchMetricData(program.serverUrl, apiParams);
+  } catch (error) {
+    console.log('Error fetching metric data: ' + error.message);
     process.exit(1);
   }
-  metric_data = resp['data-sets'][0];
 
   if (Object.keys(metric_data.values).length == 0) {
     console.log('There were no metrics found, exiting');
     process.exit(1);
   }
 
-  console.log('\nFrom Opensearch instance: ' + instance['host'] + ' and cdm: ' + instance['ver'] + '\n');
+  console.log('\nMetric data retrieved from API server: ' + program.serverUrl + '\n');
 
   if (program.outputFormat == 'json') {
     console.log(JSON.stringify(metric_data, null, 2));

--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -123,9 +123,21 @@ async function main() {
       'The URL of the metric data API server (e.g., http://localhost:3000/api/v1/metric-data)',
       'http://localhost:3000/api/v1/metric-data'
     )
-    .option('--host <host[:port]>', 'The host and optional port of the OpenSearch instance (passed to server)', save_host)
-    .option('--userpass <user:pass>', 'The user and password for the most recent --host (passed to server)', save_userpass)
-    .option('--ver <v7dev|v8dev|v9dev>', 'The Common Data Model version to use for the most recent --host (passed to server)', save_ver)
+    .option(
+      '--host <host[:port]>',
+      'The host and optional port of the OpenSearch instance (passed to server)',
+      save_host
+    )
+    .option(
+      '--userpass <user:pass>',
+      'The user and password for the most recent --host (passed to server)',
+      save_userpass
+    )
+    .option(
+      '--ver <v7dev|v8dev|v9dev>',
+      'The Common Data Model version to use for the most recent --host (passed to server)',
+      save_ver
+    )
     .option('--run <uuid>', 'The UUID from the run')
     .option('--period <uuid>', 'The UUID from the benchmark-iteration-sample-period')
     .option('--source <name>', 'The metric source, like a tool or benchmark name (sar, fio)')

--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -120,8 +120,8 @@ async function main() {
     .version('0.1.0')
     .option(
       '--server-url <url>',
-      'The URL of the metric data API server (e.g., http://localhost:3000/api/metric-data)',
-      'http://localhost:3000/api/metric-data'
+      'The URL of the metric data API server (e.g., http://localhost:3000/api/v1/metric-data)',
+      'http://localhost:3000/api/v1/metric-data'
     )
     .option('--host <host[:port]>', 'The host and optional port of the OpenSearch instance (passed to server)', save_host)
     .option('--userpass <user:pass>', 'The user and password for the most recent --host (passed to server)', save_userpass)

--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -295,7 +295,6 @@ async function main() {
       var col = 2;
       subKeys.forEach((subKey) => {
         var subMetric = subKey.replace(/<(\w+)>/, '$1');
-        i;
         labels[row][col] = subMetric;
         col++;
       });

--- a/queries/cdmq/get-result-summary.js
+++ b/queries/cdmq/get-result-summary.js
@@ -55,8 +55,20 @@ async function apiRequest(serverUrl, method, path, body) {
         try {
           parsed = JSON.parse(data);
         } catch (e) {
-          reject(new Error('Failed to parse response from ' + method + ' ' + path + ': ' + e.message +
-            '\n  Raw response (' + data.length + ' bytes): ' + JSON.stringify(data.substring(0, 200))));
+          reject(
+            new Error(
+              'Failed to parse response from ' +
+                method +
+                ' ' +
+                path +
+                ': ' +
+                e.message +
+                '\n  Raw response (' +
+                data.length +
+                ' bytes): ' +
+                JSON.stringify(data.substring(0, 200))
+            )
+          );
           return;
         }
 

--- a/queries/cdmq/get-result-summary.js
+++ b/queries/cdmq/get-result-summary.js
@@ -1,72 +1,112 @@
 //# vim: autoindent tabstop=2 shiftwidth=2 expandtab softtabstop=2 filetype=javascript
-var cdm = require('./cdm');
 var yaml = require('js-yaml');
 var program = require('commander');
-var instances = [];
+const http = require('http');
+const https = require('https');
 var summary = {};
 
 function list(val) {
   return val.split(',');
 }
 
-function save_host(host) {
-  var host_info = { host: host, header: { 'Content-Type': 'application/json' } };
-  instances.push(host_info);
+// --------------------------------------------------------------------------------------------------------------
+// HTTP client for API requests
+// --------------------------------------------------------------------------------------------------------------
+function debuglog(msg) {
+  if (program.debug) {
+    console.error('[DEBUG] ' + msg);
+  }
 }
 
-function save_userpass(userpass) {
-  if (instances.length == 0) {
-    console.log('You must specify a --host before a --userpass');
-    process.exit(1);
-  }
-  instances[instances.length - 1]['header'] = {
-    'Content-Type': 'application/json',
-    Authorization: 'Basic ' + btoa(userpass)
-  };
+async function apiRequest(serverUrl, method, path, body) {
+  debuglog(method + ' ' + path + (body ? ' body=' + JSON.stringify(body) : ''));
+  return new Promise((resolve, reject) => {
+    const url = new URL(serverUrl);
+    const isHttps = url.protocol === 'https:';
+    const client = isHttps ? https : http;
+
+    const postData = body ? JSON.stringify(body) : null;
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: path,
+      method: method,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    if (postData) {
+      options.headers['Content-Length'] = Buffer.byteLength(postData);
+    }
+
+    const req = client.request(options, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        debuglog(method + ' ' + path + ' status=' + res.statusCode + ' response=' + data.substring(0, 500));
+
+        let parsed;
+        try {
+          parsed = JSON.parse(data);
+        } catch (e) {
+          reject(new Error('Failed to parse response from ' + method + ' ' + path + ': ' + e.message +
+            '\n  Raw response (' + data.length + ' bytes): ' + JSON.stringify(data.substring(0, 200))));
+          return;
+        }
+
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(parsed);
+        } else {
+          const code = parsed.code || 'HTTP_' + res.statusCode;
+          const msg = parsed.error || data;
+          reject(new Error('[' + code + '] ' + msg));
+        }
+      });
+    });
+
+    req.on('error', (error) => {
+      reject(new Error('Failed to connect to server at ' + serverUrl + ': ' + error.message));
+    });
+
+    if (postData) {
+      req.write(postData);
+    }
+    req.end();
+  });
 }
 
-function save_ver(ver) {
-  if (instances.length == 0) {
-    console.log('You must specify a --host before a --ver');
-    process.exit(1);
-  }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
-    instances[instances.length - 1]['ver'] = ver;
-  } else {
-    console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);
-    process.exit(1);
-  }
+async function apiGet(baseUrl, path) {
+  return await apiRequest(baseUrl, 'GET', path, null);
+}
+
+async function apiPost(baseUrl, path, body) {
+  return await apiRequest(baseUrl, 'POST', path, body);
 }
 
 program
   .version('0.1.0')
   .option('--run <run-ID>')
-  .option('--host <host[:port]>', 'The host and optional port of the OpenSearch instance', save_host)
-  .option('--userpass <user:pass>', 'The user and password for the most recent --host', save_userpass)
-  .option('--ver <v7dev|v8dev|v9dev>', 'The Common Data Model version to use for the most recent --host', save_ver)
+  .option(
+    '--server-url <url>',
+    'The base URL of the CDM query server (e.g., http://localhost:3000)',
+    'http://localhost:3000'
+  )
+  .option('--host <host[:port]>', 'Ignored (accepted for backward compatibility)')
+  .option('--userpass <user:pass>', 'Ignored (accepted for backward compatibility)')
+  .option('--ver <v7dev|v8dev|v9dev>', 'Ignored (accepted for backward compatibility)')
+  .option('--user <name>', 'Filter by run name')
+  .option('--email <email>', 'Filter by email')
+  .option('--harness <harness>', 'Filter by harness')
+  .option('--debug', 'Enable debug logging of API requests and responses')
   .option('--output-dir <path>, if not used, output is to console only')
   .option('--output-format <fmt>, fmta[,fmtb]', 'one or more output formats: txt, json, yaml', list, [])
   .parse(process.argv);
-
-var termKeys = [];
-var values = [];
-
-if (program.user) {
-  termKeys.push('run.name');
-  values.push([program.user]);
-}
-if (program.email) {
-  termKeys.push('run.email');
-  values.push([program.email]);
-}
-if (program.run) {
-  termKeys.push('run.run-uuid');
-  values.push([program.run]);
-}
-if (program.harness) {
-  termKeys.push('run.harness');
-  values.push([program.harness]);
-}
 
 if (!program.outputDir) {
   program.outputDir = '';
@@ -81,92 +121,142 @@ function logOutput(str, formats) {
 }
 
 async function main() {
-  // If the user does not specify any hosts, assume localhost:9200 is used
-  if (instances.length == 0) {
-    save_host('localhost:9200');
+  var baseUrl = program.serverUrl;
+
+  // Build query params for the runs search
+  var queryParts = [];
+  if (program.run) {
+    queryParts.push('run=' + encodeURIComponent(program.run));
+  }
+  if (program.user) {
+    queryParts.push('name=' + encodeURIComponent(program.user));
+  }
+  if (program.email) {
+    queryParts.push('email=' + encodeURIComponent(program.email));
+  }
+  if (program.harness) {
+    queryParts.push('harness=' + encodeURIComponent(program.harness));
+  }
+  var queryString = queryParts.length > 0 ? '?' + queryParts.join('&') : '';
+
+  // Find matching runs
+  var runsResp;
+  try {
+    runsResp = await apiGet(baseUrl, '/api/v1/runs' + queryString);
+  } catch (error) {
+    console.log('Error searching for runs: ' + error.message);
+    process.exit(1);
   }
 
-  getInstancesInfo(instances);
-  cdm.debuglog(JSON.stringify(instances, null, 2));
-
-  // Since this query is looking for run ids (and may not inlcude run-uuid as a search term), we
-  // need to check all instances.
-  var allInstanceRunIds = [];
-  for (const instance of instances) {
-    if (invalidInstance(instance)) {
-      continue;
-    }
-    cdm.debuglog('main(): calling cdm.mSearch()');
-    var instanceRunIds = await cdm.mSearch(instance, 'run', '@*', termKeys, values, 'run.run-uuid', null, 1000);
-    cdm.debuglog('main(): returned from cdm.mSearch()');
-    cdm.debuglog('instanceRunIds:\n' + JSON.stringify(instanceRunIds, null, 2));
-    if (typeof instanceRunIds[0] != 'undefined') {
-      allInstanceRunIds.push(instanceRunIds[0]);
-    }
-  }
-  cdm.debuglog('allInstanceRunIds:\n' + JSON.stringify(allInstanceRunIds, null, 2));
-
-  var runIds = cdm.consolidateAllArrays(allInstanceRunIds);
-  cdm.debuglog('(consolidated)allInstanceRunIds:\n' + JSON.stringify(runIds, null, 2));
-
+  var runIds = runsResp.runIds;
   if (typeof runIds == 'undefined' || runIds.length == 0) {
     console.log('The run ID could not be found, exiting');
     process.exit(1);
   }
 
-  cdm.debuglog('runIds:\n' + JSON.stringify(runIds, null, 2));
   summary['runs'] = [];
   for (runIdx = 0; runIdx < runIds.length; runIdx++) {
-    cdm.debuglog('runIdx:\n' + runIdx);
     var thisRun = {};
     const runId = runIds[runIdx];
-    var instance = await findInstanceFromRun(instances, runId);
-    console.log('\nFrom Opensearch instance: ' + instance['host'] + ' and cdm: ' + instance['ver']);
-    var yearDotMonth = await findYearDotMonthFromRun(instance, runId);
+    var runPrefix = '/api/v1/run/' + runId;
+
     logOutput('\nrun-id: ' + runId, program.outputFormat);
     thisRun['run-id'] = runId;
     thisRun['iterations'] = [];
-    var tags = await cdm.getTags(instance, runId, yearDotMonth);
+
+    // Fetch tags
+    var tagsResp;
+    try {
+      tagsResp = await apiGet(baseUrl, runPrefix + '/tags');
+    } catch (error) {
+      console.log('Error fetching tags for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var tags = tagsResp.tags;
     tags.sort((a, b) => (a.name < b.name ? -1 : 1));
     thisRun['tags'] = tags;
     var tagList = '  tags: ';
-
     tags.forEach((tag) => {
       tagList += tag.name + '=' + tag.val + ' ';
     });
     logOutput(tagList, program.outputFormat);
-    var benchName = await cdm.getBenchmarkName(instance, runId, yearDotMonth);
+
+    // Fetch benchmark name
+    var benchResp;
+    try {
+      benchResp = await apiGet(baseUrl, runPrefix + '/benchmark');
+    } catch (error) {
+      console.log('Error fetching benchmark for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var benchName = benchResp.benchmark;
     var benchmarks = list(benchName);
     logOutput('  benchmark: ' + benchName, program.outputFormat);
-    var benchIterations = await cdm.getIterations(instance, runId, yearDotMonth);
+
+    // Fetch iterations
+    var iterResp;
+    try {
+      iterResp = await apiGet(baseUrl, runPrefix + '/iterations');
+    } catch (error) {
+      console.log('Error fetching iterations for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var benchIterations = iterResp.iterations;
     if (benchIterations.length == 0) {
-      cdm.debuglog('There were no iterations found, exiting');
+      console.log('There were no iterations found, exiting');
       process.exit(1);
     }
 
-    var iterParams = await cdm.mgetParams(instance, benchIterations, yearDotMonth);
-    //returns 1D array [iter]
-    var iterPrimaryPeriodNames = await cdm.mgetPrimaryPeriodName(instance, benchIterations, yearDotMonth);
-    //input: 1D array
-    //output: 2D array [iter][samp]
-    var iterSampleIds = await cdm.mgetSamples(instance, benchIterations, yearDotMonth);
-    //input: 2D array iterSampleIds: [iter][samp]
-    //output: 2D array [iter][samp]
-    var iterSampleStatuses = await cdm.mgetSampleStatuses(instance, iterSampleIds, yearDotMonth);
-    //needs 2D array iterSampleIds: [iter][samp] and 1D array iterPrimaryPeriodNames [iter]
-    //returns 2D array [iter][samp]
-    var iterPrimaryPeriodIds = await cdm.mgetPrimaryPeriodId(
-      instance,
-      iterSampleIds,
-      iterPrimaryPeriodNames,
-      yearDotMonth
-    );
-    var iterPrimaryPeriodRanges = await cdm.mgetPeriodRange(instance, iterPrimaryPeriodIds, yearDotMonth);
+    // Fetch iteration-level data in parallel: params, primary-period-name, samples, primary-metric
+    var iterBody = { iterations: benchIterations };
+    var paramsResp, periodNamesResp, samplesResp, primaryMetricsResp;
+    try {
+      [paramsResp, periodNamesResp, samplesResp, primaryMetricsResp] = await Promise.all([
+        apiPost(baseUrl, runPrefix + '/iterations/params', iterBody),
+        apiPost(baseUrl, runPrefix + '/iterations/primary-period-name', iterBody),
+        apiPost(baseUrl, runPrefix + '/iterations/samples', iterBody),
+        apiPost(baseUrl, runPrefix + '/iterations/primary-metric', iterBody)
+      ]);
+    } catch (error) {
+      console.log('Error fetching iteration data for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var iterParams = paramsResp.params;
+    var iterPrimaryPeriodNames = periodNamesResp.periodNames;
+    var iterSampleIds = samplesResp.samples;
+    var iterPrimaryMetrics = primaryMetricsResp.primaryMetrics;
+
+    // Fetch sample-level data: statuses and primary period IDs
+    var statusesResp, periodIdsResp;
+    try {
+      [statusesResp, periodIdsResp] = await Promise.all([
+        apiPost(baseUrl, runPrefix + '/samples/statuses', { sampleIds: iterSampleIds }),
+        apiPost(baseUrl, runPrefix + '/samples/primary-period-id', {
+          sampleIds: iterSampleIds,
+          periodNames: iterPrimaryPeriodNames
+        })
+      ]);
+    } catch (error) {
+      console.log('Error fetching sample data for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var iterSampleStatuses = statusesResp.statuses;
+    var iterPrimaryPeriodIds = periodIdsResp.periodIds;
+
+    // Fetch period ranges
+    var rangesResp;
+    try {
+      rangesResp = await apiPost(baseUrl, runPrefix + '/periods/range', { periodIds: iterPrimaryPeriodIds });
+    } catch (error) {
+      console.log('Error fetching period ranges for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var iterPrimaryPeriodRanges = rangesResp.ranges;
 
     // Find the params which are the same in every iteration
-    var iterPrimaryMetrics = await cdm.mgetPrimaryMetric(instance, benchIterations, yearDotMonth);
     var primaryMetrics = list(iterPrimaryMetrics[0]);
     // For now only dump params when 1 primary metric is used
+    var commonParams = [];
     if (primaryMetrics.length == 1) {
       var allParams = [];
       var allParamsCounts = [];
@@ -182,7 +272,6 @@ async function main() {
           }
         });
       });
-      var commonParams = [];
       for (var idx = 0; idx < allParams.length; idx++) {
         if (allParamsCounts[idx] == benchIterations.length) {
           commonParams.push(allParams[idx]);
@@ -197,18 +286,28 @@ async function main() {
       logOutput(commonParamsStr, program.outputFormat);
     }
 
+    // Fetch and display metric sources and types
     logOutput('  metrics:', program.outputFormat);
-    var metricSourcesSets = await cdm.mgetMetricSources(instance, [runId], yearDotMonth);
-    var metricSources = metricSourcesSets[0];
-    var theseRunIds = [];
+    var sourcesResp;
+    try {
+      sourcesResp = await apiGet(baseUrl, runPrefix + '/metric-sources');
+    } catch (error) {
+      console.log('Error fetching metric sources for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var metricSources = sourcesResp.sources;
+
+    var typesResp;
+    try {
+      typesResp = await apiPost(baseUrl, runPrefix + '/metric-types', { sources: metricSources });
+    } catch (error) {
+      console.log('Error fetching metric types for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    var metricTypes = typesResp.types;
+
     thisRun['metrics'] = [];
     for (var i = 0; i < metricSources.length; i++) {
-      theseRunIds[i] = runId;
-    }
-    var metricTypes = await cdm.mgetMetricTypes(instance, theseRunIds, metricSources, yearDotMonth);
-
-    for (var i = 0; i < metricSources.length; i++) {
-      var thisMetricSourceName = metricSources[i];
       logOutput('    source: ' + metricSources[i], program.outputFormat);
       var typeList = '      types: ';
       for (var j = 0; j < metricTypes[i].length; j++) {
@@ -219,12 +318,9 @@ async function main() {
       thisRun['metrics'].push(thisMetric);
     }
 
-    // build the sets for the mega-query
-    var metricDataSetsChunks = [];
-    var batchedQuerySize = 10;
+    // Build the sets for the metric data queries
     var benchmarks = benchName.split(',');
     var sets = [];
-    var chunkNum = 0;
     for (var i = 0; i < benchIterations.length; i++) {
       for (var j = 0; j < iterSampleIds[i].length; j++) {
         var primaryMetrics = list(iterPrimaryMetrics[i]);
@@ -233,18 +329,16 @@ async function main() {
           var type = '';
           var sourceType = primaryMetrics[k].split('::');
           if (sourceType.length == 1) {
-            // Older runs have only 1 benchmark and only have "type" in primaryMetrics
             source = benchmarks[0];
             type = primaryMetrics[k];
           } else if (sourceType.length == 2) {
-            // Newer run data embeds source and type for primaryMetric
             source = sourceType[0];
             type = sourceType[1];
           } else {
             console.log('ERROR: sourceType array is an unexpected length, ' + sourceType.length);
             process.exit(1);
           }
-          var set = {
+          sets.push({
             run: runId,
             period: iterPrimaryPeriodIds[i][j],
             source: source,
@@ -252,36 +346,49 @@ async function main() {
             begin: iterPrimaryPeriodRanges[i][j].begin,
             end: iterPrimaryPeriodRanges[i][j].end,
             resolution: 1,
-            breakout: []
-          };
-          sets.push(set);
-          if (sets.length == batchedQuerySize) {
-            // Submit a chunk of the query and save the result
-            var resp = (metricDataSetsChunks[chunkNum] = await cdm.getMetricDataSets(instance, sets, yearDotMonth));
-            if (resp['ret-code'] != 0) {
-              console.log(resp['ret-msg']);
-              process.exit(1);
-            }
-            metricDataSetsChunks[chunkNum] = resp['data-sets'];
-            chunkNum++;
-            sets = [];
-          }
+            breakout: [],
+            iterIdx: i,
+            sampIdx: j,
+            metricIdx: k
+          });
         }
       }
     }
-    if (sets.length > 0) {
-      // Submit a chunk of the query and save the result
-      var resp = await cdm.getMetricDataSets(instance, sets, yearDotMonth);
-      if (resp['ret-code'] != 0) {
-        console.log(resp['ret-msg']);
+
+    // Fetch metric data in batches
+    var batchedQuerySize = 10;
+    var metricDataResults = new Array(sets.length);
+    for (var batchStart = 0; batchStart < sets.length; batchStart += batchedQuerySize) {
+      var batchEnd = Math.min(batchStart + batchedQuerySize, sets.length);
+      var batchPromises = [];
+      for (var b = batchStart; b < batchEnd; b++) {
+        var s = sets[b];
+        batchPromises.push(
+          apiPost(baseUrl, '/api/v1/metric-data', {
+            run: s.run,
+            period: s.period,
+            source: s.source,
+            type: s.type,
+            begin: s.begin,
+            end: s.end,
+            resolution: s.resolution,
+            breakout: s.breakout
+          })
+        );
+      }
+      var batchResults;
+      try {
+        batchResults = await Promise.all(batchPromises);
+      } catch (error) {
+        console.log('Error fetching metric data for run ' + runId + ': ' + error.message);
         process.exit(1);
       }
-      metricDataSetsChunks[chunkNum] = resp['data-sets'];
-      chunkNum++;
-      sets = [];
+      for (var b = 0; b < batchResults.length; b++) {
+        metricDataResults[batchStart + b] = batchResults[b];
+      }
     }
 
-    // output the results
+    // Output the results
     var data = {};
     var numIter = {};
     var idx = 0;
@@ -358,14 +465,12 @@ async function main() {
               ' seconds'
           );
           thisSample['length'] = iterPrimaryPeriodRanges[i][j].length;
-          //for (var k=0; k<benchmarks.length; k++) {
           var primaryMetrics = list(iterPrimaryMetrics[i]);
           thisSample['values'] = {};
           for (var k = 0; k < primaryMetrics.length; k++) {
             var sourceType = primaryMetrics[k].split('::');
-            var thisChunk = Math.floor(idx / batchedQuerySize);
-            var thisIdx = idx % batchedQuerySize;
-            msampleVal = parseFloat(metricDataSetsChunks[thisChunk][thisIdx].values[''][0].value);
+            var metric_data = metricDataResults[idx];
+            msampleVal = parseFloat(metric_data.values[''][0].value);
             thisSample['values'][primaryMetrics[k]] = msampleVal;
             if (allBenchMsampleVals[k] == null) {
               allBenchMsampleVals[k] = [];

--- a/queries/cdmq/get-result-summary.js
+++ b/queries/cdmq/get-result-summary.js
@@ -156,13 +156,13 @@ async function main() {
   try {
     runsResp = await apiGet(baseUrl, '/api/v1/runs' + queryString);
   } catch (error) {
-    console.log('Error searching for runs: ' + error.message);
+    console.error('Error searching for runs: ' + error.message);
     process.exit(1);
   }
 
   var runIds = runsResp.runIds;
   if (typeof runIds == 'undefined' || runIds.length == 0) {
-    console.log('The run ID could not be found, exiting');
+    console.error('The run ID could not be found, exiting');
     process.exit(1);
   }
 
@@ -181,7 +181,7 @@ async function main() {
     try {
       tagsResp = await apiGet(baseUrl, runPrefix + '/tags');
     } catch (error) {
-      console.log('Error fetching tags for run ' + runId + ': ' + error.message);
+      console.error('Error fetching tags for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var tags = tagsResp.tags;
@@ -198,7 +198,7 @@ async function main() {
     try {
       benchResp = await apiGet(baseUrl, runPrefix + '/benchmark');
     } catch (error) {
-      console.log('Error fetching benchmark for run ' + runId + ': ' + error.message);
+      console.error('Error fetching benchmark for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var benchName = benchResp.benchmark;
@@ -210,12 +210,12 @@ async function main() {
     try {
       iterResp = await apiGet(baseUrl, runPrefix + '/iterations');
     } catch (error) {
-      console.log('Error fetching iterations for run ' + runId + ': ' + error.message);
+      console.error('Error fetching iterations for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var benchIterations = iterResp.iterations;
     if (benchIterations.length == 0) {
-      console.log('There were no iterations found, exiting');
+      console.error('There were no iterations found, exiting');
       process.exit(1);
     }
 
@@ -230,7 +230,7 @@ async function main() {
         apiPost(baseUrl, runPrefix + '/iterations/primary-metric', iterBody)
       ]);
     } catch (error) {
-      console.log('Error fetching iteration data for run ' + runId + ': ' + error.message);
+      console.error('Error fetching iteration data for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var iterParams = paramsResp.params;
@@ -249,7 +249,7 @@ async function main() {
         })
       ]);
     } catch (error) {
-      console.log('Error fetching sample data for run ' + runId + ': ' + error.message);
+      console.error('Error fetching sample data for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var iterSampleStatuses = statusesResp.statuses;
@@ -260,7 +260,7 @@ async function main() {
     try {
       rangesResp = await apiPost(baseUrl, runPrefix + '/periods/range', { periodIds: iterPrimaryPeriodIds });
     } catch (error) {
-      console.log('Error fetching period ranges for run ' + runId + ': ' + error.message);
+      console.error('Error fetching period ranges for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var iterPrimaryPeriodRanges = rangesResp.ranges;
@@ -304,7 +304,7 @@ async function main() {
     try {
       sourcesResp = await apiGet(baseUrl, runPrefix + '/metric-sources');
     } catch (error) {
-      console.log('Error fetching metric sources for run ' + runId + ': ' + error.message);
+      console.error('Error fetching metric sources for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var metricSources = sourcesResp.sources;
@@ -313,7 +313,7 @@ async function main() {
     try {
       typesResp = await apiPost(baseUrl, runPrefix + '/metric-types', { sources: metricSources });
     } catch (error) {
-      console.log('Error fetching metric types for run ' + runId + ': ' + error.message);
+      console.error('Error fetching metric types for run ' + runId + ': ' + error.message);
       process.exit(1);
     }
     var metricTypes = typesResp.types;
@@ -347,7 +347,7 @@ async function main() {
             source = sourceType[0];
             type = sourceType[1];
           } else {
-            console.log('ERROR: sourceType array is an unexpected length, ' + sourceType.length);
+            console.error('ERROR: sourceType array is an unexpected length, ' + sourceType.length);
             process.exit(1);
           }
           sets.push({
@@ -392,7 +392,7 @@ async function main() {
       try {
         batchResults = await Promise.all(batchPromises);
       } catch (error) {
-        console.log('Error fetching metric data for run ' + runId + ': ' + error.message);
+        console.error('Error fetching metric data for run ' + runId + ': ' + error.message);
         process.exit(1);
       }
       for (var b = 0; b < batchResults.length; b++) {

--- a/queries/cdmq/get-result-summary.js
+++ b/queries/cdmq/get-result-summary.js
@@ -126,6 +126,31 @@ if (!program.outputDir) {
 if (!program.outputFormat) {
   program.outputFormat = [''];
 }
+
+// When --output-dir is specified, capture console.log and console.error to files
+const fs = require('fs');
+var stdoutStream = null;
+var stderrStream = null;
+if (program.outputDir) {
+  stdoutStream = fs.createWriteStream(program.outputDir + '/get-result-summary-stdout.txt');
+  stderrStream = fs.createWriteStream(program.outputDir + '/get-result-summary-stderr.txt');
+
+  var origLog = console.log;
+  var origError = console.error;
+
+  console.log = function () {
+    var msg = Array.prototype.map.call(arguments, String).join(' ');
+    origLog.apply(console, arguments);
+    stdoutStream.write(msg + '\n');
+  };
+
+  console.error = function () {
+    var msg = Array.prototype.map.call(arguments, String).join(' ');
+    origError.apply(console, arguments);
+    stderrStream.write(msg + '\n');
+  };
+}
+
 var txt_summary = '';
 
 function logOutput(str, formats) {

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const fs = require('fs');
 const app = express();
 const cdm = require('./cdm');
 const PORT = process.env.PORT || 3000;
@@ -7,6 +8,28 @@ const { Command } = require('commander');
 const program = new Command();
 
 var instances = [];
+
+// Server log file — written to /var/lib/crucible/logs/ if it exists, otherwise cwd
+var logDir = '/var/lib/crucible/logs';
+try {
+  fs.mkdirSync(logDir, { recursive: true });
+} catch (e) {
+  logDir = '.';
+}
+var logFile = logDir + '/cdm-server.log';
+var logStream = fs.createWriteStream(logFile, { flags: 'a' });
+
+function serverLog(msg) {
+  var line = '[' + new Date().toISOString() + '] ' + msg;
+  console.log(line);
+  logStream.write(line + '\n');
+}
+
+function serverError(msg) {
+  var line = '[' + new Date().toISOString() + '] ERROR: ' + msg;
+  console.error(line);
+  logStream.write(line + '\n');
+}
 
 function save_host(host) {
   var host_info = { host: host, header: { 'Content-Type': 'application/json' } };
@@ -51,7 +74,14 @@ if (instances.length == 0) {
   save_host('localhost:9200');
 }
 
+serverLog(
+  'Starting CDM server with ' + instances.length + ' instance(s): ' + JSON.stringify(instances.map((i) => i.host))
+);
+serverLog('Log file: ' + logFile);
+
 getInstancesInfo(instances);
+
+serverLog('Instance info after discovery: ' + JSON.stringify(instances, null, 2));
 
 app.use(cors());
 app.use(express.json());
@@ -90,7 +120,7 @@ async function resolveRun(req, res, next) {
     req.cdm = { instance, yearDotMonth, runId };
     next();
   } catch (error) {
-    console.error('Error in resolveRun middleware:', error);
+    serverError('Error in resolveRun middleware:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to resolve run: ' + error.message
@@ -147,10 +177,10 @@ app.get('/api/v1/runs', async (req, res) => {
       runIds = [];
     }
 
-    console.log('[' + Date.now() + '] GET /api/v1/runs returned ' + runIds.length + ' run(s)');
+    serverLog('[' + Date.now() + '] GET /api/v1/runs returned ' + runIds.length + ' run(s)');
     res.json({ runIds: runIds });
   } catch (error) {
-    console.error('Error in GET /api/v1/runs:', error);
+    serverError('Error in GET /api/v1/runs:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to search for runs: ' + error.message
@@ -168,10 +198,10 @@ app.get('/api/v1/run/:id/tags', resolveRun, async (req, res) => {
     if (typeof tags == 'undefined') {
       tags = [];
     }
-    console.log('[' + Date.now() + '] GET /api/v1/run/' + runId + '/tags returned ' + tags.length + ' tag(s)');
+    serverLog('[' + Date.now() + '] GET /api/v1/run/' + runId + '/tags returned ' + tags.length + ' tag(s)');
     res.json({ tags: tags });
   } catch (error) {
-    console.error('Error in GET /api/v1/run/:id/tags:', error);
+    serverError('Error in GET /api/v1/run/:id/tags:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get tags: ' + error.message
@@ -192,10 +222,10 @@ app.get('/api/v1/run/:id/benchmark', resolveRun, async (req, res) => {
         error: 'No benchmark name found for run ' + runId
       });
     }
-    console.log('[' + Date.now() + '] GET /api/v1/run/' + runId + '/benchmark returned: ' + benchmarkName);
+    serverLog('[' + Date.now() + '] GET /api/v1/run/' + runId + '/benchmark returned: ' + benchmarkName);
     res.json({ benchmark: benchmarkName });
   } catch (error) {
-    console.error('Error in GET /api/v1/run/:id/benchmark:', error);
+    serverError('Error in GET /api/v1/run/:id/benchmark:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get benchmark name: ' + error.message
@@ -218,7 +248,7 @@ app.get('/api/v1/run/:id/iterations', resolveRun, async (req, res) => {
     );
     res.json({ iterations: iterations });
   } catch (error) {
-    console.error('Error in GET /api/v1/run/:id/iterations:', error);
+    serverError('Error in GET /api/v1/run/:id/iterations:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get iterations: ' + error.message
@@ -257,7 +287,7 @@ app.post('/api/v1/run/:id/iterations/params', resolveRun, async (req, res) => {
     );
     res.json({ params: params });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/iterations/params:', error);
+    serverError('Error in POST /api/v1/run/:id/iterations/params:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get iteration params: ' + error.message
@@ -296,7 +326,7 @@ app.post('/api/v1/run/:id/iterations/primary-period-name', resolveRun, async (re
     );
     res.json({ periodNames: periodNames });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/iterations/primary-period-name:', error);
+    serverError('Error in POST /api/v1/run/:id/iterations/primary-period-name:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get primary period names: ' + error.message
@@ -336,7 +366,7 @@ app.post('/api/v1/run/:id/iterations/samples', resolveRun, async (req, res) => {
     );
     res.json({ samples: samples });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/iterations/samples:', error);
+    serverError('Error in POST /api/v1/run/:id/iterations/samples:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get samples: ' + error.message
@@ -365,10 +395,10 @@ app.post('/api/v1/run/:id/samples/statuses', resolveRun, async (req, res) => {
     if (typeof statuses == 'undefined') {
       statuses = [];
     }
-    console.log('[' + Date.now() + '] POST /api/v1/run/' + runId + '/samples/statuses completed');
+    serverLog('[' + Date.now() + '] POST /api/v1/run/' + runId + '/samples/statuses completed');
     res.json({ statuses: statuses });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/samples/statuses:', error);
+    serverError('Error in POST /api/v1/run/:id/samples/statuses:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get sample statuses: ' + error.message
@@ -403,10 +433,10 @@ app.post('/api/v1/run/:id/samples/primary-period-id', resolveRun, async (req, re
     if (typeof periodIds == 'undefined') {
       periodIds = [];
     }
-    console.log('[' + Date.now() + '] POST /api/v1/run/' + runId + '/samples/primary-period-id completed');
+    serverLog('[' + Date.now() + '] POST /api/v1/run/' + runId + '/samples/primary-period-id completed');
     res.json({ periodIds: periodIds });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/samples/primary-period-id:', error);
+    serverError('Error in POST /api/v1/run/:id/samples/primary-period-id:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get primary period IDs: ' + error.message
@@ -435,10 +465,10 @@ app.post('/api/v1/run/:id/periods/range', resolveRun, async (req, res) => {
     if (typeof ranges == 'undefined') {
       ranges = [];
     }
-    console.log('[' + Date.now() + '] POST /api/v1/run/' + runId + '/periods/range completed');
+    serverLog('[' + Date.now() + '] POST /api/v1/run/' + runId + '/periods/range completed');
     res.json({ ranges: ranges });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/periods/range:', error);
+    serverError('Error in POST /api/v1/run/:id/periods/range:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get period ranges: ' + error.message
@@ -478,7 +508,7 @@ app.post('/api/v1/run/:id/iterations/primary-metric', resolveRun, async (req, re
     );
     res.json({ primaryMetrics: primaryMetrics });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/iterations/primary-metric:', error);
+    serverError('Error in POST /api/v1/run/:id/iterations/primary-metric:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get primary metrics: ' + error.message
@@ -502,7 +532,7 @@ app.get('/api/v1/run/:id/metric-sources', resolveRun, async (req, res) => {
     );
     res.json({ sources: sources });
   } catch (error) {
-    console.error('Error in GET /api/v1/run/:id/metric-sources:', error);
+    serverError('Error in GET /api/v1/run/:id/metric-sources:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get metric sources: ' + error.message
@@ -544,7 +574,7 @@ app.post('/api/v1/run/:id/metric-types', resolveRun, async (req, res) => {
     );
     res.json({ types: types });
   } catch (error) {
-    console.error('Error in POST /api/v1/run/:id/metric-types:', error);
+    serverError('Error in POST /api/v1/run/:id/metric-types:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Failed to get metric types: ' + error.message
@@ -559,7 +589,7 @@ app.post('/api/v1/metric-data', async (req, res) => {
   try {
     var { run, period, begin, end, source, type, resolution, breakout, filter, instances: reqInstances } = req.body;
 
-    console.log('[' + Date.now() + '] Fetching metric data with parameters:', {
+    serverLog('[' + Date.now() + '] Fetching metric data with parameters:', {
       run,
       period,
       begin,
@@ -663,7 +693,7 @@ app.post('/api/v1/metric-data', async (req, res) => {
     // Return the data
     res.json(metric_data);
   } catch (error) {
-    console.error('Error in /api/v1/metric-data:', error);
+    serverError('Error in /api/v1/metric-data:', error);
     res.status(500).json({
       code: 'INTERNAL_ERROR',
       error: 'Internal server error while fetching metric data',
@@ -679,7 +709,7 @@ app.get('/health', (req, res) => {
 
 // Error handling middleware
 app.use((error, req, res, next) => {
-  console.error('Unhandled error:', error);
+  serverError('Unhandled error: ' + error);
   res.status(500).json({
     code: 'INTERNAL_ERROR',
     error: 'Internal server error',
@@ -697,9 +727,9 @@ app.use((req, res) => {
 
 // Start server
 app.listen(PORT, () => {
-  console.log(`CDM Query Server running on port ${PORT}`);
-  console.log(`API endpoints: http://localhost:${PORT}/api/v1/`);
-  console.log(`Health check: http://localhost:${PORT}/health`);
+  serverLog('CDM Query Server running on port ' + PORT);
+  serverLog('API endpoints: http://localhost:' + PORT + '/api/v1/');
+  serverLog('Health check: http://localhost:' + PORT + '/health');
 });
 
 module.exports = app;

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -102,10 +102,15 @@ app.post('/api/metric-data', async (req, res) => {
     var yearDotMonth = await findYearDotMonthFromRun(instance, run);
 
     // getMetricDataSets expects breakout to be an array
-    if (typeof breakout != 'string') {
-      breakout = [];
-    } else {
+    // Handle breakout as either an array (from new client) or string (from legacy clients)
+    if (Array.isArray(breakout)) {
+      // Already an array, use as-is
+    } else if (typeof breakout === 'string') {
+      // Legacy string format, do simple split
       breakout = breakout.split(',');
+    } else {
+      // Undefined or null
+      breakout = [];
     }
     if (typeof resolution == 'undefined') {
       resolution = 1;

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -46,6 +46,11 @@ program
 
 const options = program.opts();
 
+// If the user does not specify any hosts, assume localhost:9200 is used
+if (instances.length == 0) {
+  save_host('localhost:9200');
+}
+
 getInstancesInfo(instances);
 
 app.use(cors());
@@ -54,7 +59,7 @@ app.use(express.json());
 // API endpoint to get metric data
 app.post('/api/metric-data', async (req, res) => {
   try {
-    var { run, period, begin, end, source, type, resolution, breakout, filter } = req.body;
+    var { run, period, begin, end, source, type, resolution, breakout, filter, instances: reqInstances } = req.body;
 
     console.log('[' + Date.now() + '] Fetching metric data with parameters:', {
       run,
@@ -65,30 +70,45 @@ app.post('/api/metric-data', async (req, res) => {
       type,
       resolution,
       breakout,
-      filter
+      filter,
+      instances: reqInstances ? `${reqInstances.length} instance(s) provided` : 'using server instances'
     });
+
+    // Use instances from request if provided, otherwise use server's configured instances
+    var instancesToUse = reqInstances && reqInstances.length > 0 ? reqInstances : instances;
+
+    if (!instancesToUse || instancesToUse.length === 0) {
+      errMsg = 'No OpenSearch instances configured. Either start server with --host options or provide instances in request.';
+      console.error(errMsg);
+      return res.status(500).json({ error: errMsg });
+    }
+
+    // If instances were provided in the request, we need to call getInstancesInfo on them
+    if (reqInstances && reqInstances.length > 0) {
+      getInstancesInfo(instancesToUse);
+    }
 
     var yearDotMonth;
     var instance;
     if (run != null) {
-      instance = await findInstanceFromRun(instances, run);
+      instance = await findInstanceFromRun(instancesToUse, run);
       if (instance == null) {
         errMsg =
           'Could not find run ID ' +
           period +
           ' in any of the Opensearch instances:\n' +
-          JSON.stringify(instances, null, 2);
+          JSON.stringify(instancesToUse, null, 2);
         console.error(errMsg);
         return res.status(500).json({ error: errMsg });
       }
     } else if (period != null) {
-      instance = await findInstanceFromPeriod(instances, period);
+      instance = await findInstanceFromPeriod(instancesToUse, period);
       if (instance == null) {
         errMsg =
           'Could not find period ID ' +
           period +
           ' in any of the Opensearch instances:\n' +
-          JSON.stringify(instances, null, 2);
+          JSON.stringify(instancesToUse, null, 2);
         console.error(errMsg);
         return res.status(500).json({ error: errMsg });
       }

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -56,8 +56,481 @@ getInstancesInfo(instances);
 app.use(cors());
 app.use(express.json());
 
-// API endpoint to get metric data
-app.post('/api/metric-data', async (req, res) => {
+// --------------------------------------------------------------------------------------------------------------
+// Middleware: resolve a run ID to an OpenSearch instance and yearDotMonth
+// Attaches req.cdm = { instance, yearDotMonth, runId } on success
+// --------------------------------------------------------------------------------------------------------------
+async function resolveRun(req, res, next) {
+  try {
+    const runId = req.params.id;
+    if (!runId) {
+      return res.status(400).json({
+        code: 'MISSING_RUN_ID',
+        error: 'A run ID is required'
+      });
+    }
+
+    if (!instances || instances.length === 0) {
+      return res.status(503).json({
+        code: 'NO_INSTANCES',
+        error: 'No OpenSearch instances configured'
+      });
+    }
+
+    const instance = await findInstanceFromRun(instances, runId);
+    if (instance == null) {
+      return res.status(404).json({
+        code: 'RUN_NOT_FOUND',
+        error: 'Could not find run ID ' + runId + ' in any OpenSearch instance'
+      });
+    }
+
+    const yearDotMonth = await findYearDotMonthFromRun(instance, runId);
+
+    req.cdm = { instance, yearDotMonth, runId };
+    next();
+  } catch (error) {
+    console.error('Error in resolveRun middleware:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to resolve run: ' + error.message
+    });
+  }
+}
+
+// --------------------------------------------------------------------------------------------------------------
+// GET /api/v1/runs — search for runs by filters
+// Query params: name, email, harness, run (all optional)
+// --------------------------------------------------------------------------------------------------------------
+app.get('/api/v1/runs', async (req, res) => {
+  try {
+    var termKeys = [];
+    var values = [];
+
+    if (req.query.name) {
+      termKeys.push('run.name');
+      values.push([req.query.name]);
+    }
+    if (req.query.email) {
+      termKeys.push('run.email');
+      values.push([req.query.email]);
+    }
+    if (req.query.run) {
+      termKeys.push('run.run-uuid');
+      values.push([req.query.run]);
+    }
+    if (req.query.harness) {
+      termKeys.push('run.harness');
+      values.push([req.query.harness]);
+    }
+
+    if (!instances || instances.length === 0) {
+      return res.status(503).json({
+        code: 'NO_INSTANCES',
+        error: 'No OpenSearch instances configured'
+      });
+    }
+
+    var allInstanceRunIds = [];
+    for (const instance of instances) {
+      if (invalidInstance(instance)) {
+        continue;
+      }
+      var instanceRunIds = await cdm.mSearch(instance, 'run', '@*', termKeys, values, 'run.run-uuid', null, 1000);
+      if (typeof instanceRunIds[0] != 'undefined') {
+        allInstanceRunIds.push(instanceRunIds[0]);
+      }
+    }
+
+    var runIds = cdm.consolidateAllArrays(allInstanceRunIds);
+    if (typeof runIds == 'undefined') {
+      runIds = [];
+    }
+
+    console.log('[' + Date.now() + '] GET /api/v1/runs returned ' + runIds.length + ' run(s)');
+    res.json({ runIds: runIds });
+  } catch (error) {
+    console.error('Error in GET /api/v1/runs:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to search for runs: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// GET /api/v1/run/:id/tags — get tags for a run
+// --------------------------------------------------------------------------------------------------------------
+app.get('/api/v1/run/:id/tags', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    var tags = await cdm.getTags(instance, runId, yearDotMonth);
+    if (typeof tags == 'undefined') {
+      tags = [];
+    }
+    console.log('[' + Date.now() + '] GET /api/v1/run/' + runId + '/tags returned ' + tags.length + ' tag(s)');
+    res.json({ tags: tags });
+  } catch (error) {
+    console.error('Error in GET /api/v1/run/:id/tags:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get tags: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// GET /api/v1/run/:id/benchmark — get benchmark name for a run
+// --------------------------------------------------------------------------------------------------------------
+app.get('/api/v1/run/:id/benchmark', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    var benchmarkName = await cdm.getBenchmarkName(instance, runId, yearDotMonth);
+    if (typeof benchmarkName == 'undefined' || benchmarkName == null) {
+      return res.status(404).json({
+        code: 'BENCHMARK_NOT_FOUND',
+        error: 'No benchmark name found for run ' + runId
+      });
+    }
+    console.log('[' + Date.now() + '] GET /api/v1/run/' + runId + '/benchmark returned: ' + benchmarkName);
+    res.json({ benchmark: benchmarkName });
+  } catch (error) {
+    console.error('Error in GET /api/v1/run/:id/benchmark:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get benchmark name: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// GET /api/v1/run/:id/iterations — get iteration UUIDs for a run
+// --------------------------------------------------------------------------------------------------------------
+app.get('/api/v1/run/:id/iterations', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    var iterations = await cdm.getIterations(instance, runId, yearDotMonth);
+    if (typeof iterations == 'undefined') {
+      iterations = [];
+    }
+    console.log(
+      '[' + Date.now() + '] GET /api/v1/run/' + runId + '/iterations returned ' + iterations.length + ' iteration(s)'
+    );
+    res.json({ iterations: iterations });
+  } catch (error) {
+    console.error('Error in GET /api/v1/run/:id/iterations:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get iterations: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/iterations/params — get params for iterations
+// Body: { iterations: [...] }
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/iterations/params', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { iterations } = req.body;
+
+    if (!Array.isArray(iterations) || iterations.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_ITERATIONS',
+        error: 'An array of iteration IDs is required in the request body'
+      });
+    }
+
+    var params = await cdm.mgetParams(instance, iterations, yearDotMonth);
+    if (typeof params == 'undefined') {
+      params = [];
+    }
+    console.log(
+      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/params returned params for ' +
+      iterations.length + ' iteration(s)'
+    );
+    res.json({ params: params });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/iterations/params:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get iteration params: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/iterations/primary-period-name — get primary period names
+// Body: { iterations: [...] }
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/iterations/primary-period-name', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { iterations } = req.body;
+
+    if (!Array.isArray(iterations) || iterations.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_ITERATIONS',
+        error: 'An array of iteration IDs is required in the request body'
+      });
+    }
+
+    var periodNames = await cdm.mgetPrimaryPeriodName(instance, iterations, yearDotMonth);
+    if (typeof periodNames == 'undefined') {
+      periodNames = [];
+    }
+    console.log(
+      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/primary-period-name returned ' +
+      periodNames.length + ' name(s)'
+    );
+    res.json({ periodNames: periodNames });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/iterations/primary-period-name:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get primary period names: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/iterations/samples — get sample IDs per iteration
+// Body: { iterations: [...] }
+// Returns: { samples: [[...], [...]] } (2D array indexed by iteration)
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/iterations/samples', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { iterations } = req.body;
+
+    if (!Array.isArray(iterations) || iterations.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_ITERATIONS',
+        error: 'An array of iteration IDs is required in the request body'
+      });
+    }
+
+    var samples = await cdm.mgetSamples(instance, iterations, yearDotMonth);
+    if (typeof samples == 'undefined') {
+      samples = [];
+    }
+    console.log(
+      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/samples returned samples for ' +
+      iterations.length + ' iteration(s)'
+    );
+    res.json({ samples: samples });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/iterations/samples:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get samples: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/samples/statuses — get pass/fail status per sample
+// Body: { sampleIds: [[...], [...]] } (2D array indexed by iteration)
+// Returns: { statuses: [[...], [...]] } (2D array indexed by iteration)
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/samples/statuses', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { sampleIds } = req.body;
+
+    if (!Array.isArray(sampleIds) || sampleIds.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_SAMPLE_IDS',
+        error: 'A 2D array of sample IDs is required in the request body'
+      });
+    }
+
+    var statuses = await cdm.mgetSampleStatuses(instance, sampleIds, yearDotMonth);
+    if (typeof statuses == 'undefined') {
+      statuses = [];
+    }
+    console.log('[' + Date.now() + '] POST /api/v1/run/' + runId + '/samples/statuses completed');
+    res.json({ statuses: statuses });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/samples/statuses:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get sample statuses: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/samples/primary-period-id — get primary period IDs
+// Body: { sampleIds: [[...], [...]], periodNames: [...] }
+// Returns: { periodIds: [[...], [...]] } (2D array indexed by iteration)
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/samples/primary-period-id', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { sampleIds, periodNames } = req.body;
+
+    if (!Array.isArray(sampleIds) || sampleIds.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_SAMPLE_IDS',
+        error: 'A 2D array of sample IDs is required in the request body'
+      });
+    }
+    if (!Array.isArray(periodNames) || periodNames.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_PERIOD_NAMES',
+        error: 'An array of period names is required in the request body'
+      });
+    }
+
+    var periodIds = await cdm.mgetPrimaryPeriodId(instance, sampleIds, periodNames, yearDotMonth);
+    if (typeof periodIds == 'undefined') {
+      periodIds = [];
+    }
+    console.log('[' + Date.now() + '] POST /api/v1/run/' + runId + '/samples/primary-period-id completed');
+    res.json({ periodIds: periodIds });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/samples/primary-period-id:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get primary period IDs: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/periods/range — get begin/end time for periods
+// Body: { periodIds: [[...], [...]] } (2D array indexed by iteration)
+// Returns: { ranges: [[{begin, end}, ...], ...] } (2D array indexed by iteration)
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/periods/range', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { periodIds } = req.body;
+
+    if (!Array.isArray(periodIds) || periodIds.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_PERIOD_IDS',
+        error: 'A 2D array of period IDs is required in the request body'
+      });
+    }
+
+    var ranges = await cdm.mgetPeriodRange(instance, periodIds, yearDotMonth);
+    if (typeof ranges == 'undefined') {
+      ranges = [];
+    }
+    console.log('[' + Date.now() + '] POST /api/v1/run/' + runId + '/periods/range completed');
+    res.json({ ranges: ranges });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/periods/range:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get period ranges: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/iterations/primary-metric — get primary metric per iteration
+// Body: { iterations: [...] }
+// Returns: { primaryMetrics: [...] } (1D array, one per iteration)
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/iterations/primary-metric', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { iterations } = req.body;
+
+    if (!Array.isArray(iterations) || iterations.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_ITERATIONS',
+        error: 'An array of iteration IDs is required in the request body'
+      });
+    }
+
+    var primaryMetrics = await cdm.mgetPrimaryMetric(instance, iterations, yearDotMonth);
+    if (typeof primaryMetrics == 'undefined') {
+      primaryMetrics = [];
+    }
+    console.log(
+      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/primary-metric returned ' +
+      primaryMetrics.length + ' metric(s)'
+    );
+    res.json({ primaryMetrics: primaryMetrics });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/iterations/primary-metric:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get primary metrics: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// GET /api/v1/run/:id/metric-sources — get all metric sources for a run
+// --------------------------------------------------------------------------------------------------------------
+app.get('/api/v1/run/:id/metric-sources', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    var metricSourcesSets = await cdm.mgetMetricSources(instance, [runId], yearDotMonth);
+    var sources = [];
+    if (Array.isArray(metricSourcesSets) && metricSourcesSets.length > 0) {
+      sources = metricSourcesSets[0];
+    }
+    console.log(
+      '[' + Date.now() + '] GET /api/v1/run/' + runId + '/metric-sources returned ' + sources.length + ' source(s)'
+    );
+    res.json({ sources: sources });
+  } catch (error) {
+    console.error('Error in GET /api/v1/run/:id/metric-sources:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get metric sources: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/run/:id/metric-types — get metric types per source
+// Body: { sources: [...] }
+// Returns: { types: [[...], [...]] } (2D array, one inner array per source)
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/run/:id/metric-types', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    const { sources } = req.body;
+
+    if (!Array.isArray(sources) || sources.length === 0) {
+      return res.status(400).json({
+        code: 'MISSING_SOURCES',
+        error: 'An array of metric sources is required in the request body'
+      });
+    }
+
+    // mgetMetricTypes expects parallel arrays of runIds and sources
+    var runIds = sources.map(() => runId);
+    var types = await cdm.mgetMetricTypes(instance, runIds, sources, yearDotMonth);
+    if (typeof types == 'undefined') {
+      types = [];
+    }
+    console.log(
+      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/metric-types returned types for ' +
+      sources.length + ' source(s)'
+    );
+    res.json({ types: types });
+  } catch (error) {
+    console.error('Error in POST /api/v1/run/:id/metric-types:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get metric types: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/metric-data — get metric data (existing endpoint, supports run or period)
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/metric-data', async (req, res) => {
   try {
     var { run, period, begin, end, source, type, resolution, breakout, filter, instances: reqInstances } = req.body;
 
@@ -78,9 +551,10 @@ app.post('/api/metric-data', async (req, res) => {
     var instancesToUse = reqInstances && reqInstances.length > 0 ? reqInstances : instances;
 
     if (!instancesToUse || instancesToUse.length === 0) {
-      errMsg = 'No OpenSearch instances configured. Either start server with --host options or provide instances in request.';
-      console.error(errMsg);
-      return res.status(500).json({ error: errMsg });
+      return res.status(503).json({
+        code: 'NO_INSTANCES',
+        error: 'No OpenSearch instances configured. Either start server with --host options or provide instances in request.'
+      });
     }
 
     // If instances were provided in the request, we need to call getInstancesInfo on them
@@ -93,31 +567,26 @@ app.post('/api/metric-data', async (req, res) => {
     if (run != null) {
       instance = await findInstanceFromRun(instancesToUse, run);
       if (instance == null) {
-        errMsg =
-          'Could not find run ID ' +
-          period +
-          ' in any of the Opensearch instances:\n' +
-          JSON.stringify(instancesToUse, null, 2);
-        console.error(errMsg);
-        return res.status(500).json({ error: errMsg });
+        return res.status(404).json({
+          code: 'RUN_NOT_FOUND',
+          error: 'Could not find run ID ' + run + ' in any OpenSearch instance'
+        });
       }
     } else if (period != null) {
       instance = await findInstanceFromPeriod(instancesToUse, period);
       if (instance == null) {
-        errMsg =
-          'Could not find period ID ' +
-          period +
-          ' in any of the Opensearch instances:\n' +
-          JSON.stringify(instancesToUse, null, 2);
-        console.error(errMsg);
-        return res.status(500).json({ error: errMsg });
+        return res.status(404).json({
+          code: 'PERIOD_NOT_FOUND',
+          error: 'Could not find period ID ' + period + ' in any OpenSearch instance'
+        });
       }
       // We don't yet know the yearDotMonth, so use wildcard to query all period indices
       run = await getRunFromPeriod(instance, period, '@*');
     } else {
-      errMsg = 'Neither a period nor a run ID were provided';
-      console.error(errMsg);
-      return res.status(500).json({ error: errMsg });
+      return res.status(400).json({
+        code: 'MISSING_RUN_OR_PERIOD',
+        error: 'Neither a period nor a run ID were provided'
+      });
     }
     var yearDotMonth = await findYearDotMonthFromRun(instance, run);
 
@@ -148,9 +617,10 @@ app.post('/api/metric-data', async (req, res) => {
     };
     var resp = await cdm.getMetricDataSets(instance, [set], yearDotMonth);
     if (resp['ret-code'] != 0) {
-      errMsg = resp['ret-msg'];
-      console.error(errMsg);
-      return res.status(500).json({ error: errMsg });
+      return res.status(500).json({
+        code: 'METRIC_QUERY_FAILED',
+        error: resp['ret-msg']
+      });
     }
     metric_data = resp['data-sets'][0];
 
@@ -167,8 +637,9 @@ app.post('/api/metric-data', async (req, res) => {
     // Return the data
     res.json(metric_data);
   } catch (error) {
-    console.error('Error in /api/metric-data:', error);
+    console.error('Error in /api/v1/metric-data:', error);
     res.status(500).json({
+      code: 'INTERNAL_ERROR',
       error: 'Internal server error while fetching metric data',
       details: error.message
     });
@@ -184,6 +655,7 @@ app.get('/health', (req, res) => {
 app.use((error, req, res, next) => {
   console.error('Unhandled error:', error);
   res.status(500).json({
+    code: 'INTERNAL_ERROR',
     error: 'Internal server error',
     details: process.env.NODE_ENV === 'development' ? error.message : undefined
   });
@@ -192,15 +664,16 @@ app.use((error, req, res, next) => {
 // Handle 404 for unknown routes
 app.use((req, res) => {
   res.status(404).json({
-    error: 'Route not found'
+    code: 'ROUTE_NOT_FOUND',
+    error: 'Route not found: ' + req.method + ' ' + req.originalUrl
   });
 });
 
 // Start server
 app.listen(PORT, () => {
-  console.log(`🚀 Metric Data Server running on port ${PORT}`);
-  console.log(`📊 API endpoint: http://localhost:${PORT}/api/metric-data`);
-  console.log(`💚 Health check: http://localhost:${PORT}/health`);
+  console.log(`CDM Query Server running on port ${PORT}`);
+  console.log(`API endpoints: http://localhost:${PORT}/api/v1/`);
+  console.log(`Health check: http://localhost:${PORT}/health`);
 });
 
 module.exports = app;

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -107,6 +107,9 @@ async function resolveRun(req, res, next) {
       });
     }
 
+    // Refresh instance index info before querying
+    getInstancesInfo(instances);
+
     const instance = await findInstanceFromRun(instances, runId);
     if (instance == null) {
       return res.status(404).json({
@@ -160,6 +163,9 @@ app.get('/api/v1/runs', async (req, res) => {
         error: 'No OpenSearch instances configured'
       });
     }
+
+    // Refresh instance index info before querying
+    getInstancesInfo(instances);
 
     var allInstanceRunIds = [];
     for (const instance of instances) {
@@ -613,10 +619,8 @@ app.post('/api/v1/metric-data', async (req, res) => {
       });
     }
 
-    // If instances were provided in the request, we need to call getInstancesInfo on them
-    if (reqInstances && reqInstances.length > 0) {
-      getInstancesInfo(instancesToUse);
-    }
+    // Refresh instance index info before querying
+    getInstancesInfo(instancesToUse);
 
     var yearDotMonth;
     var instance;

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -247,8 +247,13 @@ app.post('/api/v1/run/:id/iterations/params', resolveRun, async (req, res) => {
       params = [];
     }
     console.log(
-      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/params returned params for ' +
-      iterations.length + ' iteration(s)'
+      '[' +
+        Date.now() +
+        '] POST /api/v1/run/' +
+        runId +
+        '/iterations/params returned params for ' +
+        iterations.length +
+        ' iteration(s)'
     );
     res.json({ params: params });
   } catch (error) {
@@ -281,8 +286,13 @@ app.post('/api/v1/run/:id/iterations/primary-period-name', resolveRun, async (re
       periodNames = [];
     }
     console.log(
-      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/primary-period-name returned ' +
-      periodNames.length + ' name(s)'
+      '[' +
+        Date.now() +
+        '] POST /api/v1/run/' +
+        runId +
+        '/iterations/primary-period-name returned ' +
+        periodNames.length +
+        ' name(s)'
     );
     res.json({ periodNames: periodNames });
   } catch (error) {
@@ -316,8 +326,13 @@ app.post('/api/v1/run/:id/iterations/samples', resolveRun, async (req, res) => {
       samples = [];
     }
     console.log(
-      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/samples returned samples for ' +
-      iterations.length + ' iteration(s)'
+      '[' +
+        Date.now() +
+        '] POST /api/v1/run/' +
+        runId +
+        '/iterations/samples returned samples for ' +
+        iterations.length +
+        ' iteration(s)'
     );
     res.json({ samples: samples });
   } catch (error) {
@@ -453,8 +468,13 @@ app.post('/api/v1/run/:id/iterations/primary-metric', resolveRun, async (req, re
       primaryMetrics = [];
     }
     console.log(
-      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/iterations/primary-metric returned ' +
-      primaryMetrics.length + ' metric(s)'
+      '[' +
+        Date.now() +
+        '] POST /api/v1/run/' +
+        runId +
+        '/iterations/primary-metric returned ' +
+        primaryMetrics.length +
+        ' metric(s)'
     );
     res.json({ primaryMetrics: primaryMetrics });
   } catch (error) {
@@ -514,8 +534,13 @@ app.post('/api/v1/run/:id/metric-types', resolveRun, async (req, res) => {
       types = [];
     }
     console.log(
-      '[' + Date.now() + '] POST /api/v1/run/' + runId + '/metric-types returned types for ' +
-      sources.length + ' source(s)'
+      '[' +
+        Date.now() +
+        '] POST /api/v1/run/' +
+        runId +
+        '/metric-types returned types for ' +
+        sources.length +
+        ' source(s)'
     );
     res.json({ types: types });
   } catch (error) {
@@ -553,7 +578,8 @@ app.post('/api/v1/metric-data', async (req, res) => {
     if (!instancesToUse || instancesToUse.length === 0) {
       return res.status(503).json({
         code: 'NO_INSTANCES',
-        error: 'No OpenSearch instances configured. Either start server with --host options or provide instances in request.'
+        error:
+          'No OpenSearch instances configured. Either start server with --host options or provide instances in request.'
       });
     }
 


### PR DESCRIPTION
## Summary

- Add versioned API (`/api/v1/`) with 13 new fine-grained endpoints to `server.js` for querying run data (tags, benchmark, iterations, params, samples, statuses, periods, metric sources/types)
- Add `resolveRun` middleware to handle OpenSearch instance discovery and yearDotMonth resolution for all run-scoped endpoints
- Refactor `get-result-summary.js` to use the API server instead of direct cdm.js/OpenSearch calls, with `--debug` mode and `Promise.all` parallelization
- Refactor `get-metric-data.js` to use the API server (pre-existing commits on this branch)
- All endpoints return structured error responses with error codes
- Old `--host`/`--userpass`/`--ver` options accepted for backward compatibility with older crucible callers

## Test plan

- [x] Manually tested `crucible get result --run <id>` with new CDM + old crucible (backward compat)
- [x] Manually tested `crucible get result --run <id>` with new CDM + new crucible
- [x] Verified `--debug` flag traces all API requests/responses
- [ ] Test `crucible get metric` with various breakout/resolution options
- [ ] Test with multiple OpenSearch instances configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)