### PR TITLE
feat: add display step for changes action output

### DIFF
--- a/.github/workflows/cdm-ci.yaml
+++ b/.github/workflows/cdm-ci.yaml
@@ -28,6 +28,8 @@ jobs:
             .github/workflows/crucible-ci.yaml
             .github/workflows/cdm-ci.yaml
             docs/**
+      - name: Display changes
+        run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
   real-cdm-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -28,6 +28,8 @@ jobs:
             .github/workflows/crucible-ci.yaml
             .github/workflows/cdm-ci.yaml
             docs/**
+      - name: Display changes
+        run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
   call-real-core-crucible-ci:
     needs: changes


### PR DESCRIPTION
## Summary

Add a Display changes step to log the full tj-actions/changed-files outputs for visibility in the GitHub UI.

Tracking: perftool-incubator/crucible#538

🤖 Generated with [Claude Code](https://claude.com/claude-code)