### PR TITLE
feat: add workshop.json with controller image requirements and use release CI workflow

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -31,10 +31,10 @@ jobs:
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
-  call-real-core-crucible-ci:
+  call-real-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/core-release-crucible-ci.yaml@main
     with:
       ci_target: "CommonDataModel"
       ci_target_branch: "${{ github.ref }}"
@@ -44,14 +44,14 @@ jobs:
       ci_registry_auth: ${{ secrets.CRUCIBLE_CI_ENGINES_REGISTRY_AUTH }}
       quay_oauth_token: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
 
-  call-faux-core-crucible-ci:
+  call-faux-core-release-crucible-ci:
     needs: changes
     if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
-    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-crucible-ci.yaml@main
+    uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-release-crucible-ci.yaml@main
 
   crucible-ci-complete:
     runs-on: ubuntu-latest
-    needs: [ call-real-core-crucible-ci, call-faux-core-crucible-ci ]
+    needs: [ call-real-core-release-crucible-ci, call-faux-core-release-crucible-ci ]
     if: always()
     steps:
       - name: Check Results

--- a/workshop.json
+++ b/workshop.json
@@ -1,0 +1,26 @@
+{
+    "workshop": {
+        "schema": {
+            "version": "2020.03.02"
+        }
+    },
+    "userenvs": [
+        {
+            "name": "crucible-controller",
+            "requirements": [
+                "nodejs"
+            ]
+        }
+    ],
+    "requirements": [
+        {
+            "name": "nodejs",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+                    "nodejs"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Add `workshop.json` declaring nodejs as a controller image dependency for the CDM query tools
- Switch `crucible-ci.yaml` from `core-crucible-ci` to `core-release-crucible-ci` so workshop.json changes trigger a controller image rebuild

Part of the effort to decentralize controller image requirements to individual subprojects.

## Test plan
- [ ] CI passes
- [ ] Controller image builds successfully with CDM deps resolved from this workshop.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)