### PR TITLE
Fix web UI build and align CDM server logging

### DIFF
--- a/queries/cdmq/start-server.sh
+++ b/queries/cdmq/start-server.sh
@@ -5,7 +5,14 @@
 # This script starts the CommonDataModel REST API server
 # which provides metric data queries via HTTP endpoints
 
-exec >/root/start-server.stdout 2>&1
+# Set up logging to match other crucible services (opensearch, image-sourcing).
+# Log to /var/lib/crucible/logs/ if it exists, otherwise stdout only
+# (journald captures container stdout via --log-driver=journald).
+log_dir="/var/lib/crucible/logs"
+log_file="${log_dir}/cdm-server-start.log"
+if [ -d "${log_dir}" ] || mkdir -p "${log_dir}" 2>/dev/null; then
+    exec > >(tee "${log_file}") 2>&1
+fi
 
 project_dir=$(dirname `readlink -e $0`)
 pushd "$project_dir" >/dev/null
@@ -14,21 +21,21 @@ if ! command -v npm >/dev/null 2>&1; then
     popd >/dev/null
     exit 1
 fi
-echo "Resolving cdmq dependencies..." >&2
-npm install --no-fund --no-audit 2>&1 | tail -1 >&2
+echo "Resolving cdmq dependencies..."
+npm install --no-fund --no-audit 2>&1 | tail -1
 
 # Build the web UI if source exists
 if [ -d "web-ui" ] && [ -f "web-ui/package.json" ]; then
-    echo "Building web UI..." >&2
+    echo "Building web UI..."
     pushd web-ui >/dev/null
-    npm install --no-fund --no-audit 2>&1 | tail -1 >&2
-    npm run build 2>&1 >&2
+    npm install --no-fund --no-audit 2>&1 | tail -1
+    node node_modules/.bin/vite build 2>&1
     build_rc=$?
     popd >/dev/null
     if [ $build_rc -ne 0 ]; then
-        echo "Warning: web UI build failed (rc=$build_rc), server will start without UI" >&2
+        echo "Warning: web UI build failed (rc=$build_rc), server will start without UI"
     else
-        echo "Web UI built successfully" >&2
+        echo "Web UI built successfully"
     fi
 fi
 

--- a/queries/cdmq/start-server.sh
+++ b/queries/cdmq/start-server.sh
@@ -18,19 +18,19 @@ echo "Resolving cdmq dependencies..." >&2
 npm install --no-fund --no-audit 2>&1 | tail -1 >&2
 
 # Build the web UI if source exists
-#if [ -d "web-ui" ] && [ -f "web-ui/package.json" ]; then
-    #echo "Building web UI..." >&2
-    #pushd web-ui >/dev/null
-    #npm install --no-fund --no-audit 2>&1 | tail -1 >&2
-    #npm run build 2>&1 >&2
-    #build_rc=$?
-    #popd >/dev/null
-    #if [ $build_rc -ne 0 ]; then
-        #echo "Warning: web UI build failed (rc=$build_rc), server will start without UI" >&2
-    #else
-        #echo "Web UI built successfully" >&2
-    #fi
-#fi
+if [ -d "web-ui" ] && [ -f "web-ui/package.json" ]; then
+    echo "Building web UI..." >&2
+    pushd web-ui >/dev/null
+    npm install --no-fund --no-audit 2>&1 | tail -1 >&2
+    npm run build 2>&1 >&2
+    build_rc=$?
+    popd >/dev/null
+    if [ $build_rc -ne 0 ]; then
+        echo "Warning: web UI build failed (rc=$build_rc), server will start without UI" >&2
+    else
+        echo "Web UI built successfully" >&2
+    fi
+fi
 
 while true; do
     echo "Starting server.js..."

--- a/queries/cdmq/web-ui/ARCHITECTURE.md
+++ b/queries/cdmq/web-ui/ARCHITECTURE.md
@@ -34,7 +34,8 @@ queries/cdmq/
 ├── server.js               # Express HTTP server (REST API + static file serving)
 ├── start-server.sh         # Startup script (npm install, web-ui build, launch)
 ├── web-ui/                 # React application (this project)
-│   ├── ARCHITECTURE.md     # This file
+│   ├── ARCHITECTURE.md     # This file (initial architecture overview)
+│   ├── DESIGN.md           # Comprehensive design & implementation guide
 │   ├── vite.config.js      # Vite configuration (proxy, build output)
 │   ├── index.html          # HTML entry point
 │   ├── package.json        # Dependencies (react, recharts, vite)
@@ -46,9 +47,11 @@ queries/cdmq/
 │   │   ├── api/
 │   │   │   └── cdm.js      # API client (fetch wrappers for all CDM endpoints)
 │   │   └── components/
-│   │       ├── SearchPanel.jsx     # Phase 1: Search form and iteration loading
-│   │       ├── IterationTable.jsx  # Phase 1: Results table with sorting/filtering
-│   │       ├── SelectionBar.jsx    # Phase 1: Persistent selection display
+│   │       ├── SearchPanel.jsx     # Search form with autocomplete filters
+│   │       ├── IterationTable.jsx  # Results table with sorting/filtering
+│   │       ├── SelectionBar.jsx    # Persistent selection display
+│   │       ├── CompareView.jsx     # Bar charts with grouping, metrics, breakouts
+│   │       ├── AutocompleteInput.jsx # Reusable dropdown (single/multi-select)
 │   │       └── DebugConsole.jsx    # Timing/debug console panel
 │   └── dist/               # Build output (served by Express in production)
 ```
@@ -336,23 +339,20 @@ crucible start opensearch   # Starts OpenSearch + CDM server (builds web UI)
 # Open http://<host>:3000
 ```
 
-## Future Phases
+## Implementation Status
 
-### Phase 2: Result Summary (Comparison Bar Charts)
+### Phase 1: Search & Selection — Implemented
+See sections above and [DESIGN.md](DESIGN.md) for full details.
 
-Compare primary metrics across selected iterations using bar charts:
-- Clustering by param value, run, or tag
-- Supplemental metrics as side-by-side bars or overlay dots
-- Recharts BarChart component
+### Phase 2: Compare — Implemented
+Bar chart comparison with hierarchical group-by headers, supplemental metrics (overlay + panel modes), breakouts with filter/sample selection, click-to-pin with reference lines, URL state sharing. See [DESIGN.md](DESIGN.md) for full details.
 
-### Phase 3: Deep Dive (Time-Series Line Charts)
+### Phase 3: Deep Dive (Time-Series Line Charts) — Planned
 
 Interactive time-series exploration:
 - Line charts with zoom/pan
-- Right-click context menu for breakout exploration
-- Per-line breakout state (different lines can have different breakout depths)
+- Breakout exploration
 - Iteration overlay with relative time alignment
-- Recharts or Plotly for advanced interactivity
 
 ## Design Decisions & Rationale
 
@@ -369,13 +369,13 @@ Eliminates CORS configuration, simplifies deployment (one container, one
 port), and means the UI is automatically available wherever the CDM API runs.
 No separate web server or reverse proxy needed.
 
-### Why `<datalist>` instead of a select dropdown library?
+### Why a custom AutocompleteInput instead of a select library?
 
-Native `<datalist>` provides autocomplete from known values while still
-allowing free text input. This is important because:
-- Users may want to type a value not yet in the system
-- No additional React library dependency
-- Works with the existing input styling
+`AutocompleteInput.jsx` replaces native `<datalist>` elements with a custom
+dropdown that supports multi-select (chips), context-aware partitioning
+(present vs. absent values based on current search results), and keyboard
+navigation. This avoids third-party React dropdown dependencies while
+providing the UX needed for multi-value tag/param filtering.
 
 ### Why client-side iteration filtering after server-side run filtering?
 

--- a/queries/cdmq/web-ui/DESIGN.md
+++ b/queries/cdmq/web-ui/DESIGN.md
@@ -85,7 +85,8 @@ App
 | `iterations` (search results) | App | SearchPanel (as prop), IterationTable |
 | `selected` (Map of iterationId -> iteration) | App | IterationTable, SelectionBar, CompareView |
 | `view` (search/compare/deepdive) | App | Controls which view renders |
-| `groupBy`, `seriesBy` | App | CompareView |
+| `groupByList` | App | CompareView |
+| `hiddenFields` | App | CompareView |
 | `filters` (search form state) | SearchPanel | Internal; exposed via ref |
 | `metricValues` (primary metric) | IterationTable | Internal (fetched on demand) |
 | `supplementalMetrics` | CompareView | Internal |
@@ -249,7 +250,7 @@ The text input at the top filters iterations by param name/value:
 
 ### Chart Architecture
 
-The chart uses Recharts' `ComposedChart` which supports mixing Bar and Line components. The chart data is a flat array of entries, one per iteration, with gap entries inserted between groups.
+The chart uses Recharts' `ComposedChart` which supports mixing Bar and Line components. The chart data is a flat array of entries, one per iteration, with gap entries inserted between groups. Chart height is capped at 30% of viewport width to prevent overly tall charts.
 
 **Chart data entry structure:**
 ```javascript
@@ -336,18 +337,21 @@ Users can hide specific params/tags from the compare view:
 4. Choose display mode: **Overlay** (line on primary chart with right Y-axis) or **Own Panel** (separate bar chart)
 5. Click "Add" — fetches metric values for all selected iterations
 
-### Metric Control Panel
+### Primary Metric Refinement
 
-Each added metric is displayed as a row with:
+The primary metric chart includes a "Refine" button that adds the primary metric as a supplemental metric panel. This gives the primary metric the same controls as supplemental metrics: breakouts, filters, sample selection, and chart type. Once refined, the button disappears to prevent duplicates.
+
+### Metric Control Row
+
+Each metric's controls render directly below its chart panel (not grouped at the top). Controls include:
 - Colored left border (consistent color across chart and panel)
-- Metric name (source::type) in monospace font
-- Display mode badge ("overlay" or "panel")
 - **+ Breakout** dropdown (populated with `remainingBreakouts` from server)
 - **Chart type** selector (Bars, Stacked, Lines) — visible when breakouts are active
 - **Sample** selector — choose which sample to display (auto-selects the sample closest to the primary metric mean)
 - **Filter** input — accepts `gt:N`, `ge:N`, `lt:N`, `le:N` syntax for server-side label filtering
 - Remove button (x)
 - Active breakout chips with editable filter values
+- Overlay-mode metric controls render below the primary chart
 
 ### Per-Sample Selection
 
@@ -485,25 +489,41 @@ http://host:3000/#%7B%22benchmark%22%3A%22uperf%22%2C%22start%22%3A%222026.01%22
   params: [{ arg: "wsize", val: "64,256" }],
   selectedRuns: ["uuid1", "uuid2"],  // Run IDs (not iteration IDs — much shorter)
   view: "compare",
-  groupBy: ["param:nthreads", "param:protocol"]  // Array of group-by dimensions
+  groupBy: ["param:nthreads", "param:protocol"],  // Array of group-by dimensions
+  hidden: ["param:primary-metric"],  // Hidden field dimensions
+  metrics: [                   // Supplemental metrics with full configuration
+    {
+      source: "mpstat",
+      type: "Busy-CPU",
+      display: "panel",
+      chartType: "bar",        // Omitted if "bar" (default)
+      breakouts: ["direction"],
+      filter: "gt:0",
+      sampleIndex: 2
+    }
+  ]
 }
 ```
 
 ### Restoration Flow
 
 1. On mount: `decodeState(window.location.hash)` parsed, stored in `restoredState.current`
-2. `groupByList` set immediately (handles both array and legacy single-string format)
-3. `view` NOT set yet (deferred until search completes)
-4. After SearchPanel mounts: `setFiltersAndSearch(filters)` called via ref
-5. SearchPanel updates filters, triggers search via `pendingSearch` ref + useEffect
-6. `handleSearchResults` receives results, auto-selects iterations from matching run IDs
-7. View switched to saved view (e.g., "compare")
-8. `restoredState.current` cleared to prevent re-application on next search
-9. If no groupByList was saved, auto-group runs on CompareView mount
+2. `groupByList` and `hiddenFields` set immediately (handles both array and legacy single-string format)
+3. `restoredMetrics` saved to React state (not ref) so it survives timing between mount and CompareView render
+4. `view` NOT set yet (deferred until search completes)
+5. After SearchPanel mounts: `setFiltersAndSearch(filters)` called via ref
+6. SearchPanel updates filters, triggers search via `pendingSearch` ref + useEffect
+7. `handleSearchResults` receives results, auto-selects iterations from matching run IDs
+8. View switched to saved view (e.g., "compare")
+9. `restoredState.current` cleared to prevent re-application on next search
+10. CompareView mounts and detects `restoredMetrics` prop — re-fetches each metric with saved configuration (source, type, display, chartType, breakouts, filter, sampleIndex)
+11. If no groupByList was saved, auto-group runs on CompareView mount
 
-**Key design decision:** View switch is deferred until after search + selection to avoid showing an empty Compare view while data is loading.
-
-**Filters are saved in `lastFilters.current`** on every search result, because SearchPanel is unmounted when the user navigates to Compare view. The Share button uses `searchRef.current.getFilters() || lastFilters.current`.
+**Key design decisions:**
+- View switch is deferred until after search + selection to avoid showing an empty Compare view while data is loading.
+- `restoredMetrics` uses React state (not a ref) because the ref would be cleared before CompareView mounts and reads it.
+- Filters are saved in `lastFilters.current` on every search result, because SearchPanel is unmounted when the user navigates to Compare view. The Share button uses `searchRef.current.getFilters() || lastFilters.current`.
+- Supplemental metrics are retrieved from CompareView via `compareRef.current.getSupplementalMetrics()` (exposed via `useImperativeHandle`).
 
 ---
 
@@ -661,11 +681,9 @@ Primary metric values are NOT loaded with iteration details (would add ~7 second
 - **Large result sets:** Searching across many months with hundreds of runs can be slow due to sequential OpenSearch queries
 - **Bundle size:** Recharts adds ~400KB to the bundle. Code splitting could help.
 - **Breakout label parsing:** CDM may omit breakout dimensions with single values from labels, making label-to-dimension mapping imperfect. The sidebar uses segment-based grouping to work around this.
-- **Supplemental metric in URL state:** Currently supplemental metrics, breakouts, and hidden fields are not encoded in the Share URL
 
 ### Planned Features
 
 - **Deep Dive view:** Time-series line charts with zoom/pan and interactive breakout exploration
 - **Save/load workflows:** Server-side or localStorage persistence of named workflows
-- **Supplemental metrics in URL state:** Encode added metrics, breakouts, and display modes in the Share URL
 - **Drag-to-reorder:** Group-by chips currently use arrow buttons; drag-and-drop would be more intuitive


### PR DESCRIPTION
## Summary
- Re-enable web UI build in `start-server.sh` (was commented out during development)
- Fix vite not found in container by using explicit path (`node node_modules/.bin/vite build`)
- Align CDM server logging with other crucible services (opensearch, image-sourcing) — output goes to both journald and `/var/lib/crucible/logs/cdm-server-start.log` via `tee`
- Update DESIGN.md and ARCHITECTURE.md to document recent feature additions (URL state for metrics/hidden fields, metric restoration flow, Phase 2 completion)

## Test plan
- [ ] Fresh `crucible start opensearch` builds the web UI successfully
- [ ] Web UI is accessible at port 3000
- [ ] Startup/build output appears in `/var/lib/crucible/logs/cdm-server-start.log`
- [ ] Server runtime logs continue to `/var/lib/crucible/logs/cdm-server.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)