### PR TITLE
Compare and search view refinements

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -1056,6 +1056,38 @@ mgetMetricNames = async function (instance, runIds, sources, types, yearDotMonth
 exports.mgetMetricNames = mgetMetricNames;
 
 // --------------------------------------------------------------------------------------------------------------
+// For a list of breakout dimension names, get the distinct values for each dimension.
+// Returns an object: { "hostname": ["host1", "host2"], "num": ["0", "1", "2"], ... }
+mgetBreakoutValues = async function (instance, runIds, source, type, breakoutNames, yearDotMonth) {
+  if (!breakoutNames || breakoutNames.length === 0) return {};
+  // Build one msearch query per breakout name, each with a terms aggregation
+  var jsonArr = [];
+  for (var i = 0; i < breakoutNames.length; i++) {
+    var req = { query: { bool: { filter: [] } }, size: 0 };
+    // Filter by all runIds using a terms query (OR)
+    req.query.bool.filter.push({ terms: { 'run.run-uuid': runIds } });
+    req.query.bool.filter.push({ term: { 'metric_desc.source': source } });
+    req.query.bool.filter.push({ term: { 'metric_desc.type': type } });
+    req.aggs = { source: { terms: { field: 'metric_desc.names.' + breakoutNames[i], size: bigQuerySize } } };
+    jsonArr.push('{}');
+    jsonArr.push(JSON.stringify(req));
+  }
+  var responses = await esJsonArrRequest(instance, 'metric_desc', '/_msearch', jsonArr, yearDotMonth);
+  var result = {};
+  for (var i = 0; i < breakoutNames.length; i++) {
+    var values = [];
+    if (responses[i] && responses[i].aggregations && responses[i].aggregations.source && Array.isArray(responses[i].aggregations.source.buckets)) {
+      responses[i].aggregations.source.buckets.forEach(function (bucket) {
+        values.push(String(bucket.key));
+      });
+    }
+    result[breakoutNames[i]] = values;
+  }
+  return result;
+};
+exports.mgetBreakoutValues = mgetBreakoutValues;
+
+// --------------------------------------------------------------------------------------------------------------
 getMetricNames = async function (instance, runId, source, type, yearDotMonth) {
   return (await mgetMetricNames(instance, [runId], [source], [type], yearDotMonth))[0];
 };

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -1082,6 +1082,42 @@ app.post('/api/v1/iterations/metric-types', async (req, res) => {
 });
 
 // --------------------------------------------------------------------------------------------------------------
+// POST /api/v1/iterations/breakout-values — get distinct values for each breakout dimension
+// Body: { runIds: [...], start, end, source, type, breakouts: ["hostname", "num", ...] }
+// Returns: { breakouts: { "hostname": ["host1", "host2"], "num": ["0", "1"] } }
+// --------------------------------------------------------------------------------------------------------------
+app.post('/api/v1/iterations/breakout-values', async (req, res) => {
+  try {
+    const { runIds, start, end, source, type, breakouts } = req.body;
+    if (!Array.isArray(runIds) || runIds.length === 0 || !source || !type || !Array.isArray(breakouts)) {
+      return res.status(400).json({ code: 'MISSING_PARAMS', error: 'runIds, source, type, and breakouts are required' });
+    }
+    getInstancesInfo(instances);
+    var merged = {};
+    for (const inst of instances) {
+      if (invalidInstance(inst)) continue;
+      var ydm = cdm.buildYearDotMonthRange(inst, 'run', start || null, end || null);
+      var result = await cdm.mgetBreakoutValues(inst, runIds, source, type, breakouts, ydm);
+      // Merge values across instances
+      Object.keys(result).forEach(function (dim) {
+        if (!merged[dim]) merged[dim] = new Set();
+        result[dim].forEach(function (v) { merged[dim].add(v); });
+      });
+    }
+    // Convert Sets to sorted arrays
+    var response = {};
+    Object.keys(merged).forEach(function (dim) {
+      response[dim] = Array.from(merged[dim]).sort();
+    });
+    serverLog('POST /api/v1/iterations/breakout-values: ' + source + '::' + type + ' -> ' + Object.keys(response).map(function (k) { return k + ':' + response[k].length; }).join(', '));
+    res.json({ breakouts: response });
+  } catch (error) {
+    serverError('Error in POST /api/v1/iterations/breakout-values: ' + error);
+    res.status(500).json({ code: 'INTERNAL_ERROR', error: 'Failed to get breakout values: ' + error.message });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
 // POST /api/v1/iterations/supplemental-metric — get values for a specific metric source/type
 // Body: { runIds: [...], start, end, source, type, breakout: [...] }
 // Returns: { values: { iterationId: { labels: { label: { mean, stddevPct, sampleValues } }, remainingBreakouts: [...] } } }

--- a/queries/cdmq/web-ui/DESIGN.md
+++ b/queries/cdmq/web-ui/DESIGN.md
@@ -206,26 +206,42 @@ This is the core data structure passed around the UI. Each iteration object is a
 
 ### Visual Design
 
-The iteration table uses several visual techniques to reduce redundancy and guide users:
+The iteration table uses hierarchical grouping to organize iterations by their varying dimensions:
 
-**Run grouping:**
-- Iterations from the same run are grouped together with alternating background colors
-- Run ID, date, and a "select all" checkbox occupy a single rowSpanned cell on the left
-- A heavier border separates different run groups
+**Hierarchical grouping:**
+- All varying dimensions (params, tags, run ID, date, benchmark) are auto-computed
+- Dimensions sorted by distinct value count (fewest first) — same algorithm as compare view
+- Each dimension gets its own column with a header showing the dimension name
+- Group cells use `rowSpan` to span all child iterations, with checkboxes for bulk selection
+- Alternating background colors distinguish top-level groups
 
-**Common vs. Unique:**
-- **Common section** (above the table): params/tags/benchmark that have the same value across ALL displayed iterations — shown once, not repeated per row
-- **Unique column**: params/tags/benchmark that VARY across displayed iterations — each iteration row shows its own values
-- This is computed globally across all iterations (not per-run like the server's `uniqueParams`)
+**Column controls (in header):**
+- **`<` / `>`**: Reorder columns (changes grouping hierarchy)
+- **`▲` / `▼`**: Toggle sort direction (ascending/descending) per dimension
+- **`×`**: Hide dimension column (shown as strikethrough chip in "Hidden:" area, click to restore)
+
+**Date as independent dimension:**
+- Run date is its own group-by column, separate from run ID
+- Can be moved independently (e.g., to the rightmost position)
+- Sorted by timestamp with natural sort (supports descending for newest-first)
+- Displayed as formatted date/time string
+
+**Common section** (above the table): params/tags/benchmark that have the same value across ALL displayed iterations — shown once, not repeated in the table.
+
+**Details column**: Shows remaining varying items not covered by group headers. Color-coded legend chips (`bench`, `tag`, `param`) displayed in the header bar.
 
 **Clickable filters:**
-- Unique param/tag badges in the table are clickable — clicking adds them as search filters
+- Group cell param/tag badges are clickable — clicking adds them as search filters
 - This calls `SearchPanel.addTagFilter()` or `addParamFilter()` via the ref exposed by `useImperativeHandle`
 
 **Primary metric values:**
 - Not loaded with the initial search (too slow for many iterations)
 - "Show Values" button triggers a separate API call (`/iterations/metric-values`)
 - Values displayed inline: `uperf::Gbps 1234.56 (2.3%)`
+
+**Text wrapping:**
+- Long values wrap at natural separators (`-`, `_`, `.`, `,`, `/`, `:`) using zero-width spaces inserted by `wrapFriendly()`
+- `overflow-wrap: break-word` without `word-break: break-all` ensures breaks only at separator boundaries
 
 ### Param Filter
 
@@ -345,7 +361,7 @@ The primary metric chart includes a "Refine" button that adds the primary metric
 
 Each metric's controls render directly below its chart panel (not grouped at the top). Controls include:
 - Colored left border (consistent color across chart and panel)
-- **+ Breakout** dropdown (populated with `remainingBreakouts` from server)
+- **+ Breakout** button — opens a custom dropdown (see Breakout Value Preview below)
 - **Chart type** selector (Bars, Stacked, Lines) — visible when breakouts are active
 - **Sample** selector — choose which sample to display (auto-selects the sample closest to the primary metric mean)
 - **Filter** input — accepts `gt:N`, `ge:N`, `lt:N`, `le:N` syntax for server-side label filtering
@@ -361,17 +377,30 @@ Supplemental metrics query a single sample instead of averaging across all:
 - Sample dropdown shows each sample's primary metric value for reference
 - Filters work correctly since they operate on single-sample data
 
+### Breakout Value Preview
+
+The "+ Breakout" button opens a custom div-based dropdown (not a native `<select>`) that shows:
+- Each remaining breakout dimension as a row
+- **Dimension name** (bold) followed by an **"all"** chip and individual **value chips**
+- Values fetched lazily on first open via `POST /api/v1/iterations/breakout-values`, cached per source::type
+- **Single-value dimensions** dimmed to 35% opacity and sorted to the bottom
+- **Multi-value dimensions** sorted to the top, full opacity
+- Value chips are **clickable toggles** — select specific values to pre-filter the breakout
+- Clicking **"all"** adds the breakout with no filter
+- Clicking **"Add"** (appears when specific values selected) adds the breakout as `name=val1+val2`
+
 ### Breakout Workflow
 
-1. Click "+ Breakout" dropdown, select a dimension (e.g., "direction")
-2. Client re-queries the metric with `breakout: ["direction"]`
-3. Server returns multi-label values: `{ "<rx>": { mean, ... }, "<tx>": { mean, ... } }`
-4. Server also returns updated `remainingBreakouts` for further drilling
-5. Chart renders one bar/line per label; chart type selectable (Bars/Stacked/Lines)
-6. User can add another breakout level (e.g., "hostname") — labels become `"<rx>-<host1>"`, etc.
-7. Breakout chips have editable filter inputs accepting exact values, `val1+val2`, `r/regex/`, or `R/regex/`
-8. "Apply" button re-queries with the filter applied
-9. Removing a breakout re-queries with the reduced breakout array
+1. Click "+ Breakout" — dropdown shows dimensions with their values
+2. Click "all" or select specific values and click "Add"
+3. Client re-queries the metric with `breakout: ["direction"]` (or `["direction=rx+tx"]` if filtered)
+4. Server returns multi-label values: `{ "<rx>": { mean, ... }, "<tx>": { mean, ... } }`
+5. Server also returns updated `remainingBreakouts` for further drilling
+6. Chart renders one bar/line per label; chart type selectable (Bars/Stacked/Lines)
+7. User can add another breakout level (e.g., "hostname") — labels become `"<rx>-<host1>"`, etc.
+8. Breakout chips have editable filter inputs accepting exact values, `val1+val2`, `r/regex/`, or `R/regex/`
+9. "Apply" button re-queries with the filter applied
+10. Removing a breakout re-queries with the reduced breakout array
 
 ### Data Format
 
@@ -574,6 +603,9 @@ The `/iterations/details` endpoint accepts `{ runIds, start, end }` and returns 
 | POST | `/api/v1/iterations/metric-sources` | Available metric sources across runs |
 | POST | `/api/v1/iterations/metric-types` | Types for a given source |
 | POST | `/api/v1/iterations/supplemental-metric` | Fetch metric values with optional breakouts |
+| POST | `/api/v1/iterations/breakout-values` | Distinct values per breakout dimension |
+
+The breakout-values endpoint accepts `{ runIds, start, end, source, type, breakouts: [...] }` and returns `{ breakouts: { "hostname": ["h1", "h2"], "num": ["0", "1"] } }`. Uses a single `_msearch` request with one terms aggregation per breakout dimension on `metric_desc.names.<dim>`. Results cached client-side per source::type.
 
 The supplemental-metric endpoint accepts `{ iterations, runIds, start, end, source, type, breakout, filter, sampleIndex }`:
 - `iterations`: array of `{iterationId, runId}` for targeted queries (avoids discovering all iterations from runIds)
@@ -633,6 +665,7 @@ These endpoints use a `resolveRun` middleware that finds the OpenSearch instance
 - `mgetParams`, `mgetSamples`, `mgetPrimaryMetric`, `mgetPrimaryPeriodName` — Iteration-level
 - `mgetSampleStatuses`, `mgetPrimaryPeriodId`, `mgetPeriodRange` — Sample/period-level
 - `mgetMetricSources`, `mgetMetricTypes` — Metric discovery
+- `mgetBreakoutValues` — Distinct values per breakout dimension via terms aggregation on `metric_desc.names.*`
 - `getMetricDataSets` — Full metric data retrieval with breakout support
 
 **Important:** `mgetPrimaryMetric` and `mgetPrimaryPeriodName` return 1D arrays (collapsed from 2D). Do NOT access `result[i][0]` — use `result[i]` directly. Accessing `[0]` on a string returns just the first character (e.g., "measurement"[0] = "m").

--- a/queries/cdmq/web-ui/src/api/cdm.js
+++ b/queries/cdmq/web-ui/src/api/cdm.js
@@ -129,6 +129,17 @@ export async function getSupplementalMetric(params) {
   });
 }
 
+export async function getBreakoutValues(params) {
+  return request('POST', '/iterations/breakout-values', {
+    runIds: params.runIds,
+    start: params.start,
+    end: params.end,
+    source: params.source,
+    type: params.type,
+    breakouts: params.breakouts,
+  });
+}
+
 export async function getMetricData(params) {
   return request('POST', `/metric-data`, params);
 }

--- a/queries/cdmq/web-ui/src/components/CompareView.jsx
+++ b/queries/cdmq/web-ui/src/components/CompareView.jsx
@@ -579,9 +579,12 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
       if (o.value === 'none') return;
       var vals = new Set();
       iterations.forEach(function (it) {
-        vals.add(getDimValue(it, o.value));
+        var v = getDimValue(it, o.value);
+        if (v !== '') vals.add(v); // skip empty (missing tag/param)
       });
-      dimCounts.push({ value: o.value, count: vals.size });
+      if (vals.size > 1) {
+        dimCounts.push({ value: o.value, count: vals.size });
+      }
     });
     // Sort by distinct count ascending (fewest values = best grouping level)
     dimCounts.sort(function (a, b) { return a.count - b.count; });
@@ -1287,128 +1290,6 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
 
   return (
     <div className="compare-view">
-      <div className="compare-controls">
-        <div className="compare-control">
-          <label>Group by</label>
-          {groupByList.map(function (dim, gi) {
-            return (
-              <span key={gi} className="compare-groupby-chip">
-                {gi > 0 && (
-                  <button className="compare-chip-arrow" onClick={function () {
-                    var next = groupByList.slice();
-                    next[gi] = next[gi - 1];
-                    next[gi - 1] = dim;
-                    setGroupByList(next);
-                  }} title="Move left">&lsaquo;</button>
-                )}
-                <span className="compare-chip-label">{dimOptions.find(function (o) { return o.value === dim; })?.label || dim}</span>
-                {gi < groupByList.length - 1 && (
-                  <button className="compare-chip-arrow" onClick={function () {
-                    var next = groupByList.slice();
-                    next[gi] = next[gi + 1];
-                    next[gi + 1] = dim;
-                    setGroupByList(next);
-                  }} title="Move right">&rsaquo;</button>
-                )}
-                <button onClick={function () { setGroupByList(groupByList.filter(function (_, i) { return i !== gi; })); }}>&times;</button>
-              </span>
-            );
-          })}
-          <select
-            value=""
-            onChange={function (e) {
-              if (e.target.value && !groupByList.includes(e.target.value)) {
-                setGroupByList(groupByList.concat([e.target.value]));
-              }
-            }}
-          >
-            <option value="">{groupByList.length === 0 ? 'None' : '+ Add'}</option>
-            {dimOptions.filter(function (o) { return o.value !== 'none' && !groupByList.includes(o.value); }).map(function (o) {
-              return <option key={o.value} value={o.value}>{o.label}</option>;
-            })}
-          </select>
-          <button className="btn btn-sm btn-secondary" onClick={handleAutoGroup} title="Auto-select group-by dimensions to minimize bar labels">
-            Auto
-          </button>
-          {groupByList.length > 0 && (
-            <button className="btn btn-sm btn-secondary" onClick={function () { setGroupByList([]); }}>
-              Clear
-            </button>
-          )}
-        </div>
-        <div className="compare-control">
-          <label>Hide</label>
-          {hiddenFields.map(function (dim, hi) {
-            var opt = allDimOptions.find(function (o) { return o.value === dim; });
-            return (
-              <span key={hi} className="compare-hidden-chip">
-                {opt ? opt.label : dim}
-                <button onClick={function () { setHiddenFields(hiddenFields.filter(function (_, i) { return i !== hi; })); }}>&times;</button>
-              </span>
-            );
-          })}
-          <select
-            value=""
-            onChange={function (e) {
-              if (e.target.value && !hiddenFields.includes(e.target.value)) {
-                // Also remove from groupByList and seriesBy if hidden
-                setHiddenFields(hiddenFields.concat([e.target.value]));
-                if (groupByList.includes(e.target.value)) {
-                  setGroupByList(groupByList.filter(function (d) { return d !== e.target.value; }));
-                }
-              }
-            }}
-          >
-            <option value="">{hiddenFields.length === 0 ? 'None' : '+ Hide'}</option>
-            {allDimOptions.filter(function (o) { return !hiddenFields.includes(o.value); }).map(function (o) {
-              return <option key={o.value} value={o.value}>{o.label}</option>;
-            })}
-          </select>
-        </div>
-      </div>
-      <div className="compare-add-metric-bar">
-        {!showAddMetric && (
-          <button className="btn btn-sm btn-secondary" onClick={handleShowAddMetric}>
-            + Add Metric
-          </button>
-        )}
-        {showAddMetric && (
-          <div className="compare-control">
-            <label>Source</label>
-            <select value={addMetricSource} onChange={function (e) { handleSourceChange(e.target.value); }}>
-              <option value="">Select...</option>
-              {(availableSources || []).map(function (s) { return <option key={s} value={s}>{s}</option>; })}
-            </select>
-          </div>
-        )}
-        {showAddMetric && addMetricSource && (
-          <div className="compare-control">
-            <label>Type</label>
-            <select value={addMetricType} onChange={function (e) { setAddMetricType(e.target.value); }}>
-              <option value="">Select...</option>
-              {(availableTypes || []).map(function (t) { return <option key={t} value={t}>{t}</option>; })}
-            </select>
-          </div>
-        )}
-        {showAddMetric && addMetricSource && addMetricType && (
-          <div className="compare-control">
-            <label>Display</label>
-            <div className="compare-display-toggle">
-              <button className={'btn btn-sm ' + (addMetricDisplay === 'overlay' ? 'btn-primary' : 'btn-secondary')} onClick={function () { setAddMetricDisplay('overlay'); }}>Overlay</button>
-              <button className={'btn btn-sm ' + (addMetricDisplay === 'panel' ? 'btn-primary' : 'btn-secondary')} onClick={function () { setAddMetricDisplay('panel'); }}>Own Panel</button>
-            </div>
-          </div>
-        )}
-        {showAddMetric && addMetricSource && addMetricType && (
-          <button className="btn btn-sm btn-primary" onClick={handleAddMetric} disabled={addMetricLoading}>
-            {addMetricLoading ? <><span className="spinner" style={{ marginRight: 4 }} /> Loading...</> : 'Add'}
-          </button>
-        )}
-        {showAddMetric && (
-          <button className="btn btn-sm btn-secondary" onClick={function () { setShowAddMetric(false); }}>Cancel</button>
-        )}
-      </div>
-
       {charts.map(function (chart, ci) {
         var nonGapData = chart.data.filter(function (d) { return !d.isGap; });
         if (nonGapData.length === 0) {
@@ -1640,13 +1521,41 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
             <div className="compare-chart-with-labels">
               <div className="compare-yaxis-label compare-yaxis-left">{chart.metricName}</div>
               <div className="compare-chart-area">
-            {/* Hierarchical group-by headers — inside chart-area for alignment */}
+            {/* Toolbar: hidden dims, add, auto, clear — above headers */}
+            <div className="compare-hier-toolbar">
+              {hiddenFields.map(function (dim) {
+                var opt = allDimOptions.find(function (o) { return o.value === dim; });
+                return (
+                  <span key={dim} className="compare-hier-hidden-chip" onClick={function () {
+                    setHiddenFields(hiddenFields.filter(function (d) { return d !== dim; }));
+                    if (!groupByList.includes(dim)) setGroupByList(groupByList.concat([dim]));
+                  }} title="Click to restore">{opt ? opt.label : dim}</span>
+                );
+              })}
+              {dimOptions.filter(function (o) { return o.value !== 'none' && !groupByList.includes(o.value) && !hiddenFields.includes(o.value); }).length > 0 && (
+                <select className="compare-hier-add-select" value="" onChange={function (e) {
+                  if (e.target.value && !groupByList.includes(e.target.value)) {
+                    setGroupByList(groupByList.concat([e.target.value]));
+                  }
+                }}>
+                  <option value="">+ Add</option>
+                  {dimOptions.filter(function (o) { return o.value !== 'none' && !groupByList.includes(o.value) && !hiddenFields.includes(o.value); }).map(function (o) {
+                    return <option key={o.value} value={o.value}>{o.label}</option>;
+                  })}
+                </select>
+              )}
+              <button className="btn btn-sm btn-secondary" onClick={handleAutoGroup} style={{ fontSize: 10, padding: '2px 6px' }}>Auto</button>
+              {groupByList.length > 0 && (
+                <button className="btn btn-sm btn-secondary" onClick={function () { setGroupByList([]); }} style={{ fontSize: 10, padding: '2px 6px' }}>Clear</button>
+              )}
+            </div>
+            {/* Hierarchical group-by headers with inline controls */}
             {hasGroupBy(groupByList) && (function () {
               var nonGaps = chart.data.filter(function (d) { return !d.isGap; });
               var iterMap = {};
               iterations.forEach(function (it) { iterMap[it.iterationId] = it; });
               var levels = [];
-              groupByList.forEach(function (dim) {
+              groupByList.forEach(function (dim, dimIdx) {
                 var spans = [];
                 var currentVal = null;
                 var currentCount = 0;
@@ -1661,11 +1570,13 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
                   currentCount++;
                 });
                 if (currentVal !== null) spans.push({ value: formatDimValue(dim, currentVal), count: currentCount });
-                levels.push({ label: formatDimLabel(dim), spans: spans });
+                // Skip dimensions with only one span (single value across all iterations)
+                if (spans.length <= 1) return;
+                levels.push({ label: formatDimLabel(dim), dim: dim, dimIdx: dimIdx, spans: spans });
               });
               return levels.map(function (level, li) {
                 return (
-                  <div key={li} className="compare-hier-row" style={{ marginLeft: 60, marginRight: 30 }}>
+                  <div key={li} className="compare-hier-row">
                     <div className="compare-hier-label">{level.label}</div>
                     <div className="compare-hier-spans">
                       {level.spans.map(function (span, si2) {
@@ -1675,6 +1586,28 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
                           </div>
                         );
                       })}
+                    </div>
+                    <div className="compare-hier-controls">
+                      {level.dimIdx > 0 && (
+                        <button className="compare-hier-btn" onClick={function () {
+                          var next = groupByList.slice();
+                          next[level.dimIdx] = next[level.dimIdx - 1];
+                          next[level.dimIdx - 1] = level.dim;
+                          setGroupByList(next);
+                        }} title="Move up">&#x25B2;</button>
+                      )}
+                      {level.dimIdx < groupByList.length - 1 && (
+                        <button className="compare-hier-btn" onClick={function () {
+                          var next = groupByList.slice();
+                          next[level.dimIdx] = next[level.dimIdx + 1];
+                          next[level.dimIdx + 1] = level.dim;
+                          setGroupByList(next);
+                        }} title="Move down">&#x25BC;</button>
+                      )}
+                      <button className="compare-hier-btn compare-hier-hide" onClick={function () {
+                        setGroupByList(groupByList.filter(function (d) { return d !== level.dim; }));
+                        setHiddenFields(hiddenFields.concat([level.dim]));
+                      }} title="Hide this dimension">&times;</button>
                     </div>
                   </div>
                 );
@@ -2113,6 +2046,49 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
           </div>
         );
       })}
+
+      <div className="compare-add-metric-bar">
+        {!showAddMetric && (
+          <button className="btn btn-sm btn-secondary" onClick={handleShowAddMetric}>
+            + Add Metric
+          </button>
+        )}
+        {showAddMetric && (
+          <div className="compare-control">
+            <label>Source</label>
+            <select value={addMetricSource} onChange={function (e) { handleSourceChange(e.target.value); }}>
+              <option value="">Select...</option>
+              {(availableSources || []).map(function (s) { return <option key={s} value={s}>{s}</option>; })}
+            </select>
+          </div>
+        )}
+        {showAddMetric && addMetricSource && (
+          <div className="compare-control">
+            <label>Type</label>
+            <select value={addMetricType} onChange={function (e) { setAddMetricType(e.target.value); }}>
+              <option value="">Select...</option>
+              {(availableTypes || []).map(function (t) { return <option key={t} value={t}>{t}</option>; })}
+            </select>
+          </div>
+        )}
+        {showAddMetric && addMetricSource && addMetricType && (
+          <div className="compare-control">
+            <label>Display</label>
+            <div className="compare-display-toggle">
+              <button className={'btn btn-sm ' + (addMetricDisplay === 'overlay' ? 'btn-primary' : 'btn-secondary')} onClick={function () { setAddMetricDisplay('overlay'); }}>Overlay</button>
+              <button className={'btn btn-sm ' + (addMetricDisplay === 'panel' ? 'btn-primary' : 'btn-secondary')} onClick={function () { setAddMetricDisplay('panel'); }}>Own Panel</button>
+            </div>
+          </div>
+        )}
+        {showAddMetric && addMetricSource && addMetricType && (
+          <button className="btn btn-sm btn-primary" onClick={handleAddMetric} disabled={addMetricLoading}>
+            {addMetricLoading ? <><span className="spinner" style={{ marginRight: 4 }} /> Loading...</> : 'Add'}
+          </button>
+        )}
+        {showAddMetric && (
+          <button className="btn btn-sm btn-secondary" onClick={function () { setShowAddMetric(false); }}>Cancel</button>
+        )}
+      </div>
 
     </div>
   );

--- a/queries/cdmq/web-ui/src/components/CompareView.jsx
+++ b/queries/cdmq/web-ui/src/components/CompareView.jsx
@@ -504,6 +504,22 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
   var [addMetricDisplay, setAddMetricDisplay] = useState('panel'); // 'overlay' or 'panel'
   var [showAddMetric, setShowAddMetric] = useState(false);
   var [pinnedEntry, setPinnedEntry] = useState(null);
+  var [breakoutValueCache, setBreakoutValueCache] = useState({}); // { "source::type": { "hostname": ["h1","h2"], ... } }
+  var [openBreakoutDropdown, setOpenBreakoutDropdown] = useState(null); // index of metric with open dropdown
+  var [breakoutSelections, setBreakoutSelections] = useState({}); // { "dimName": Set of selected values }
+  var breakoutDropdownRef = useRef(null);
+
+  // Close breakout dropdown on outside click
+  useEffect(function () {
+    if (openBreakoutDropdown == null) return;
+    function handleClick(e) {
+      if (breakoutDropdownRef.current && !breakoutDropdownRef.current.contains(e.target)) {
+        setOpenBreakoutDropdown(null);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return function () { document.removeEventListener('mousedown', handleClick); };
+  }, [openBreakoutDropdown]);
 
   var iterations = useMemo(function () {
     return Array.from(selected.values());
@@ -699,6 +715,26 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
       setAddMetricLoading(false);
     });
   }, [iterations, addMetricSource, addMetricType, addMetricDisplay, supplementalMetrics]);
+
+  // Fetch breakout distinct values for a metric's remaining breakouts (lazy, cached)
+  function fetchBreakoutValues(source, type, breakoutNames) {
+    var cacheKey = source + '::' + type;
+    if (breakoutValueCache[cacheKey]) return; // already fetched
+    if (!breakoutNames || breakoutNames.length === 0) return;
+    var ctx = getRunContext();
+    api.getBreakoutValues({
+      runIds: ctx.runIds, start: ctx.start, end: ctx.end,
+      source: source, type: type, breakouts: breakoutNames,
+    }).then(function (res) {
+      setBreakoutValueCache(function (prev) {
+        var next = Object.assign({}, prev);
+        next[cacheKey] = res.breakouts || {};
+        return next;
+      });
+    }).catch(function (err) {
+      console.error('Failed to fetch breakout values:', err);
+    });
+  }
 
   var handleAddBreakout = useCallback(function (si, breakoutName) {
     var sm = supplementalMetrics[si];
@@ -1098,12 +1134,90 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
       <div key={'ctrl-' + si} className="compare-metric-row" style={{ borderLeftColor: color }}>
         <div className="compare-metric-row-header">
           {sm.loading && <span className="spinner" style={{ marginLeft: 8 }} />}
-          {!sm.loading && sm.remainingBreakouts && sm.remainingBreakouts.length > 0 && (
-            <select className="compare-breakout-select" value="" onChange={function (e) { if (e.target.value) handleAddBreakout(si, e.target.value); }}>
-              <option value="">+ Breakout</option>
-              {sm.remainingBreakouts.map(function (b) { return <option key={b} value={b}>{b}</option>; })}
-            </select>
-          )}
+          {!sm.loading && sm.remainingBreakouts && sm.remainingBreakouts.length > 0 && (function () {
+            var cacheKey = sm.source + '::' + sm.type;
+            var bvCache = breakoutValueCache[cacheKey] || {};
+            var isOpen = openBreakoutDropdown === si;
+            // Sort: multi-value breakouts first, single-value last; alphabetical within each group
+            var sortedBreakouts = sm.remainingBreakouts.slice().sort(function (a, b) {
+              var ca = bvCache[a] ? bvCache[a].length : -1;
+              var cb = bvCache[b] ? bvCache[b].length : -1;
+              var aMulti = ca === -1 || ca > 1 ? 1 : 0;
+              var bMulti = cb === -1 || cb > 1 ? 1 : 0;
+              if (aMulti !== bMulti) return bMulti - aMulti;
+              if (a < b) return -1;
+              if (a > b) return 1;
+              return 0;
+            });
+            return (
+              <div className="breakout-dropdown-wrap" ref={isOpen ? breakoutDropdownRef : undefined}>
+                <button className="btn btn-sm btn-secondary breakout-dropdown-trigger" onClick={function () {
+                  if (isOpen) {
+                    setOpenBreakoutDropdown(null);
+                    setBreakoutSelections({});
+                  } else {
+                    setOpenBreakoutDropdown(si);
+                    setBreakoutSelections({});
+                    fetchBreakoutValues(sm.source, sm.type, sm.remainingBreakouts);
+                  }
+                }}>+ Breakout</button>
+                {isOpen && (
+                  <div className="breakout-dropdown-menu">
+                    {sortedBreakouts.map(function (b) {
+                      var vals = bvCache[b];
+                      var count = vals ? vals.length : null;
+                      var isSingle = count === 1;
+                      var selected_vals = breakoutSelections[b]; // Set or undefined
+                      var hasSelection = selected_vals && selected_vals.size > 0;
+                      var allSelected = hasSelection && vals && selected_vals.size === vals.length;
+                      return (
+                        <div key={b} className={'breakout-dropdown-item' + (isSingle ? ' breakout-single' : '')}>
+                          <div className="breakout-dropdown-values">
+                            <span className="breakout-dropdown-label">{b}</span>
+                            <span className={'breakout-dropdown-val breakout-val-all' + (!hasSelection || allSelected ? ' breakout-val-selected' : ' breakout-val-unselected')}
+                              onClick={function (e) {
+                                e.stopPropagation();
+                                setOpenBreakoutDropdown(null);
+                                setBreakoutSelections({});
+                                handleAddBreakout(si, b);
+                              }}
+                            >all</span>
+                            {vals && vals.map(function (v) {
+                              var isSelected = hasSelection && selected_vals.has(v);
+                              return (
+                                <span key={v}
+                                  className={'breakout-dropdown-val' + (isSelected ? ' breakout-val-selected' : '') + (hasSelection && !isSelected && !allSelected ? ' breakout-val-unselected' : '')}
+                                  onClick={function (e) {
+                                    e.stopPropagation();
+                                    setBreakoutSelections(function (prev) {
+                                      var next = Object.assign({}, prev);
+                                      var set = next[b] ? new Set(next[b]) : new Set();
+                                      if (set.has(v)) { set.delete(v); } else { set.add(v); }
+                                      if (set.size === 0) { delete next[b]; } else { next[b] = set; }
+                                      return next;
+                                    });
+                                  }}
+                                >{v}</span>
+                              );
+                            })}
+                            {hasSelection && !allSelected && (
+                              <button className="btn btn-sm btn-secondary breakout-dropdown-add" onClick={function (e) {
+                                e.stopPropagation();
+                                var breakoutStr = b + '=' + Array.from(selected_vals).join('+');
+                                setOpenBreakoutDropdown(null);
+                                setBreakoutSelections({});
+                                handleAddBreakout(si, breakoutStr);
+                              }}>Add</button>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })()}
           {sm.breakouts.length > 0 && (
             <select className="compare-breakout-select" value={sm.chartType || 'bar'} onChange={function (e) { handleChartTypeChange(si, e.target.value); }}>
               <option value="bar">Bars</option>

--- a/queries/cdmq/web-ui/src/components/CompareView.jsx
+++ b/queries/cdmq/web-ui/src/components/CompareView.jsx
@@ -905,12 +905,14 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
       var varyingKeys = cv.varyingKeys;
       var commonItems = cv.common;
 
-      // Sort by compound group-by value, then series-by value (natural/numeric sort)
+      // Sort by each group-by dimension individually (natural/numeric sort per dimension)
       var sorted = iters.slice().sort(function (a, b) {
-        var ga = getCompoundGroupValue(a, groupByList);
-        var gb = getCompoundGroupValue(b, groupByList);
-        var cmp = naturalCompare(ga, gb);
-        if (cmp !== 0) return cmp;
+        for (var gi = 0; gi < groupByList.length; gi++) {
+          var va = getDimValue(a, groupByList[gi]);
+          var vb = getDimValue(b, groupByList[gi]);
+          var cmp = naturalCompare(va, vb);
+          if (cmp !== 0) return cmp;
+        }
         return 0;
       });
 
@@ -1001,8 +1003,8 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
               entry['supp_' + si + '_error'] = computeStddev(lv);
               entry['supp_' + si + '_samples'] = lv.sampleValues ? lv.sampleValues.length : 0;
             }
-            // For breakouts with multiple labels, also store per-label data
-            if (labelKeys.length > 1) {
+            // Store per-label data for breakout sidebar display
+            if (labelKeys.length >= 1) {
               labelKeys.forEach(function (lk) {
                 var lv = smv.labels[lk];
                 entry['supp_' + si + '_' + lk] = lv.mean;
@@ -1058,6 +1060,21 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
 
     return result;
   }, [iterations, metricValues, groupByList, supplementalMetrics, hiddenSet]);
+
+  // Resolve the pinned entry from current chart data so sidebars always
+  // read fresh data (pinnedEntry.entry may be stale after chart recomputation)
+  var resolvedPinnedEntry = useMemo(function () {
+    if (!pinnedEntry || !pinnedEntry.entry) return null;
+    var itId = pinnedEntry.entry.iterationId;
+    for (var ci = 0; ci < charts.length; ci++) {
+      for (var di = 0; di < charts[ci].data.length; di++) {
+        if (charts[ci].data[di].iterationId === itId) {
+          return { entry: charts[ci].data[di], metricName: pinnedEntry.metricName };
+        }
+      }
+    }
+    return pinnedEntry; // fallback to original if not found
+  }, [pinnedEntry, charts]);
 
   if (loading) {
     return (
@@ -1473,8 +1490,8 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
                     </div>
                     {supplementalMetrics.length > 0 && <div className="compare-yaxis-label compare-yaxis-right">&nbsp;</div>}
                     <div className="compare-sidebar" style={{ maxHeight: 180 }}>
-                    {pinnedEntry && pinnedEntry.entry && !pinnedEntry.entry.isGap ? (function () {
-                      var e = pinnedEntry.entry;
+                    {resolvedPinnedEntry && resolvedPinnedEntry.entry && !resolvedPinnedEntry.entry.isGap ? (function () {
+                      var e = resolvedPinnedEntry.entry;
                       if (sm.breakouts.length > 0) {
                         var prefix = dataKey + '_';
                         var flatItems = [];
@@ -1703,8 +1720,8 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
                 <div className="compare-yaxis-label compare-yaxis-right">&nbsp;</div>
               ) : null}
               <div className="compare-sidebar" style={{ maxHeight: chartHeight }}>
-                {pinnedEntry && pinnedEntry.entry && !pinnedEntry.entry.isGap && pinnedEntry.entry.value != null ? (function () {
-                  var e = pinnedEntry.entry;
+                {resolvedPinnedEntry && resolvedPinnedEntry.entry && !resolvedPinnedEntry.entry.isGap && resolvedPinnedEntry.entry.value != null ? (function () {
+                  var e = resolvedPinnedEntry.entry;
                   var items = [];
                   var pmText = formatValue(e.value);
                   if (e.samples > 1 && e.stddevPct != null) pmText += ' (\u00b1' + e.stddevPct.toFixed(1) + '%)';
@@ -1939,8 +1956,8 @@ const CompareView = forwardRef(function CompareView({ selected, groupByList, set
                     </div>
                     {supplementalMetrics.length > 0 && <div className="compare-yaxis-label compare-yaxis-right">&nbsp;</div>}
                     <div className="compare-sidebar" style={{ maxHeight: 180 }}>
-                    {pinnedEntry && pinnedEntry.entry && !pinnedEntry.entry.isGap ? (function () {
-                      var e = pinnedEntry.entry;
+                    {resolvedPinnedEntry && resolvedPinnedEntry.entry && !resolvedPinnedEntry.entry.isGap ? (function () {
+                      var e = resolvedPinnedEntry.entry;
                       if (sm.breakouts.length > 0) {
                         var prefix = dataKey + '_';
                         var flatItems = [];

--- a/queries/cdmq/web-ui/src/components/IterationTable.jsx
+++ b/queries/cdmq/web-ui/src/components/IterationTable.jsx
@@ -49,6 +49,7 @@ function naturalCompare(a, b) {
 function getDimValue(it, dim) {
   if (!dim || dim === 'none') return '__all__';
   if (dim === 'run') return it.runId;
+  if (dim === 'date') return it.runBegin || '0';
   if (dim === 'benchmark') return it.benchmark || '';
   if (dim.startsWith('param:')) {
     var arg = dim.substring(6);
@@ -63,10 +64,21 @@ function getDimValue(it, dim) {
   return '';
 }
 
+// Format the display value for a dimension (used in group cells)
+function formatDimDisplayValue(dim, value) {
+  if (dim === 'date') {
+    if (!value || value === '0') return '-';
+    var d = new Date(Number(value));
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  return value;
+}
+
 // Get a display label for a dimension
 function formatDimLabel(dim) {
   if (!dim || dim === 'none') return '';
   if (dim === 'run') return 'run';
+  if (dim === 'date') return 'date';
   if (dim === 'benchmark') return 'benchmark';
   if (dim.startsWith('param:')) return dim.substring(6);
   if (dim.startsWith('tag:')) return dim.substring(4);
@@ -106,8 +118,14 @@ function computeGroupDims(iterations) {
       tagValues[t.name].add(t.val);
     });
   }
+  // Count distinct dates (by run — each run has one date)
+  var dates = new Set();
+  for (var j = 0; j < iterations.length; j++) {
+    if (iterations[j].runBegin) dates.add(iterations[j].runBegin);
+  }
   var dims = [];
   if (runs.size > 1) dims.push({ dim: 'run', count: runs.size });
+  if (dates.size > 1) dims.push({ dim: 'date', count: dates.size });
   if (benchmarks.size > 1) dims.push({ dim: 'benchmark', count: benchmarks.size });
   Object.keys(paramValues).sort().forEach(function (arg) {
     if (paramValues[arg].size > 1) dims.push({ dim: 'param:' + arg, count: paramValues[arg].size });
@@ -121,8 +139,8 @@ function computeGroupDims(iterations) {
 }
 
 // Build a recursive tree grouping iterations by each dimension level
-// Returns: { value, dim, children: [...subtrees], iterations: [...leaf iterations] }
-function buildGroupTree(iterations, dims, depth) {
+// sortDirs is an object: { dim: 'asc' | 'desc' }, defaults to 'asc'
+function buildGroupTree(iterations, dims, depth, sortDirs) {
   if (depth >= dims.length) {
     // Leaf level: return individual iterations
     return { iterations: iterations };
@@ -138,10 +156,14 @@ function buildGroupTree(iterations, dims, depth) {
     }
     groups[val].push(it);
   });
-  // Sort group keys naturally
-  groupOrder.sort(naturalCompare);
+  // Sort group keys naturally, respecting per-dimension sort direction
+  var dir = (sortDirs && sortDirs[dim]) || 'asc';
+  groupOrder.sort(function (a, b) {
+    var cmp = naturalCompare(a, b);
+    return dir === 'desc' ? -cmp : cmp;
+  });
   var children = groupOrder.map(function (val) {
-    var subtree = buildGroupTree(groups[val], dims, depth + 1);
+    var subtree = buildGroupTree(groups[val], dims, depth + 1, sortDirs);
     subtree.value = val;
     subtree.dim = dim;
     return subtree;
@@ -354,17 +376,19 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
     return common;
   }, [iterations]);
 
-  // Group-by dimensions as state so user can reorder/hide
+  // Group-by dimensions as state so user can reorder/hide/sort
   const [groupDims, setGroupDims] = useState([]);
   const [hiddenDims, setHiddenDims] = useState([]);
+  const [dimSortDir, setDimSortDir] = useState({}); // { dim: 'asc' | 'desc' }, default asc
   const prevIterCount = useRef(0);
 
-  // Auto-compute group dims when iterations change (reset hidden)
+  // Auto-compute group dims when iterations change (reset hidden/sort)
   useEffect(function () {
     if (iterations.length !== prevIterCount.current) {
       prevIterCount.current = iterations.length;
       setGroupDims(computeGroupDims(iterations));
       setHiddenDims([]);
+      setDimSortDir({});
     }
   }, [iterations]);
 
@@ -381,9 +405,9 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
         return { type: 'leaf', iteration: it, depth: 0, coveredDims: [] };
       });
     }
-    var tree = buildGroupTree(sorted, activeGroupDims, 0);
+    var tree = buildGroupTree(sorted, activeGroupDims, 0, dimSortDir);
     return flattenTree(tree, 0, [], activeGroupDims);
-  }, [sorted, activeGroupDims]);
+  }, [sorted, activeGroupDims, dimSortDir]);
 
   // Reorder group dimensions (operates on the full groupDims list)
   function moveGroupDim(dim, direction) {
@@ -407,6 +431,14 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
 
   function unhideGroupDim(dim) {
     setHiddenDims(function (prev) { return prev.filter(function (d) { return d !== dim; }); });
+  }
+
+  function toggleDimSort(dim) {
+    setDimSortDir(function (prev) {
+      var next = Object.assign({}, prev);
+      next[dim] = prev[dim] === 'desc' ? 'asc' : 'desc';
+      return next;
+    });
   }
 
   // For leaf rows, compute which varying items are NOT covered by group headers
@@ -529,6 +561,9 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
         <h2>Iterations {iterations.length > 0 && `(${iterations.length})`}</h2>
         {iterations.length > 0 && (
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <span className="benchmark-badge" style={{fontSize:9}}>bench</span>
+            <span className="tag" style={{fontSize:9}}>tag</span>
+            <span className="param" style={{fontSize:9}}>param</span>
             <button
               className="btn btn-sm btn-secondary"
               onClick={fetchMetricValues}
@@ -586,17 +621,21 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
             <tr>
               {activeGroupDims.map(function (dim, di) {
                 var label = formatDimLabel(dim);
+                var sortDir = dimSortDir[dim] || 'asc';
                 return (
                   <th key={dim} className="group-header-th">
-                    <div className="group-header-label">
+                    <span className={'group-header-name ' + dimChipClass(dim)}>{label}</span>
+                    <div className="group-header-controls">
                       {di > 0 && (
                         <button className="group-reorder-btn" onClick={function () { moveGroupDim(dim, -1); }} title="Move left">&lt;</button>
                       )}
-                      <span className={'group-header-name ' + dimChipClass(dim)}>{label}</span>
+                      <button className={'group-sort-btn' + (sortDir === 'desc' ? ' sort-desc' : '')} onClick={function () { toggleDimSort(dim); }} title={sortDir === 'asc' ? 'Sort descending' : 'Sort ascending'}>
+                        {sortDir === 'asc' ? '\u25B2' : '\u25BC'}
+                      </button>
+                      <button className="group-hide-btn" onClick={function () { hideGroupDim(dim); }} title="Hide this dimension">&times;</button>
                       {di < activeGroupDims.length - 1 && (
                         <button className="group-reorder-btn" onClick={function () { moveGroupDim(dim, 1); }} title="Move right">&gt;</button>
                       )}
-                      <button className="group-hide-btn" onClick={function () { hideGroupDim(dim); }} title="Hide this dimension">&times;</button>
                     </div>
                   </th>
                 );
@@ -691,7 +730,7 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
                       var chipClass = dimChipClass(cell.dim);
                       var label = formatDimLabel(cell.dim);
 
-                      // For run dimension, show run ID, date, and link
+                      // For run dimension, show run ID as a link
                       if (cell.dim === 'run') {
                         var runIt = cell.iterations[0];
                         return (
@@ -703,18 +742,17 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
                                 onChange={function () { onToggleSelectAll(cell.iterations); }}
                                 title={'Select all ' + cell.rowSpan + ' iteration(s) in this group'}
                               />
-                              <div className="group-cell-detail">
-                                {buildRunUrl(runIt.runSource) ? (
-                                  <a className="run-id" href={buildRunUrl(runIt.runSource)} target="_blank" rel="noopener noreferrer">{wrapFriendly(displayValue)}</a>
-                                ) : (
-                                  <span className="run-id">{wrapFriendly(displayValue)}</span>
-                                )}
-                                <div className="run-date">{formatDate(runIt.runBegin)}</div>
-                              </div>
+                              {buildRunUrl(runIt.runSource) ? (
+                                <a className="run-id" href={buildRunUrl(runIt.runSource)} target="_blank" rel="noopener noreferrer">{wrapFriendly(displayValue)}</a>
+                              ) : (
+                                <span className="run-id">{wrapFriendly(displayValue)}</span>
+                              )}
                             </div>
                           </td>
                         );
                       }
+
+                      var formattedValue = formatDimDisplayValue(cell.dim, displayValue);
 
                       return (
                         <td key={cell.dim + ':' + cell.value} rowSpan={cell.rowSpan} className="group-cell" onClick={function (e) { e.stopPropagation(); }}>
@@ -726,15 +764,15 @@ export default function IterationTable({ iterations, selected, onToggleSelect, o
                               title={'Select all ' + cell.rowSpan + ' iteration(s) in this group'}
                             />
                             <span
-                              className={chipClass + ' clickable-filter'}
-                              title={'Click to filter by ' + label + '=' + displayValue}
+                              className={chipClass + (cell.dim.startsWith('tag:') || cell.dim.startsWith('param:') ? ' clickable-filter' : '')}
+                              title={cell.dim.startsWith('tag:') || cell.dim.startsWith('param:') ? 'Click to filter by ' + label + '=' + displayValue : formattedValue}
                               onClick={function (e) {
                                 e.stopPropagation();
                                 if (cell.dim.startsWith('tag:')) onAddTagFilter(label, displayValue);
                                 else if (cell.dim.startsWith('param:')) onAddParamFilter(label, displayValue);
                               }}
                             >
-                              {wrapFriendly(displayValue)}
+                              {wrapFriendly(formattedValue)}
                             </span>
                           </div>
                         </td>

--- a/queries/cdmq/web-ui/src/index.css
+++ b/queries/cdmq/web-ui/src/index.css
@@ -676,7 +676,6 @@ body {
   vertical-align: middle;
   border-right: 1px solid var(--border-strong);
   padding: 6px 10px;
-  max-width: 15vw;
 }
 
 .group-cell-content {
@@ -686,21 +685,15 @@ body {
   max-width: 100%;
 }
 
-/* Allow chips inside group cells to wrap at natural separators */
+/* Allow chips inside group cells to wrap at zero-width space points
+   inserted by wrapFriendly() — do NOT use word-break: break-all */
 .group-cell .tag,
 .group-cell .param,
-.group-cell .benchmark-badge {
-  white-space: normal;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  max-width: 100%;
-}
-
-/* Run IDs in group cells should also wrap */
+.group-cell .benchmark-badge,
 .group-cell .run-id {
   white-space: normal;
   overflow-wrap: break-word;
-  word-break: break-all;
+  max-width: 100%;
 }
 
 .group-cell-detail {
@@ -713,19 +706,22 @@ body {
   text-align: center;
   border-right: 1px solid var(--border-strong);
   padding: 4px 6px;
-}
-
-.group-header-label {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
+  white-space: nowrap;
 }
 
 .group-header-name {
   font-size: 11px;
   padding: 2px 6px;
   border-radius: 3px;
+  display: inline-block;
+}
+
+.group-header-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  margin-top: 3px;
 }
 
 .group-reorder-btn {
@@ -743,6 +739,27 @@ body {
   background: var(--accent-light);
   color: var(--accent);
   border-color: var(--accent);
+}
+
+.group-sort-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 8px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.group-sort-btn:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.group-sort-btn.sort-desc {
+  color: var(--accent);
 }
 
 .group-hide-btn {

--- a/queries/cdmq/web-ui/src/index.css
+++ b/queries/cdmq/web-ui/src/index.css
@@ -1134,6 +1134,109 @@ a.run-id:hover {
   cursor: pointer;
 }
 
+/* Custom breakout dropdown */
+.breakout-dropdown-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.breakout-dropdown-trigger {
+  font-size: 11px;
+}
+
+.breakout-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  min-width: 220px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  margin-top: 2px;
+}
+
+.breakout-dropdown-item {
+  padding: 6px 10px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+}
+
+.breakout-dropdown-item:last-child {
+  border-bottom: none;
+}
+
+.breakout-dropdown-item:hover {
+  background: var(--accent-light);
+}
+
+.breakout-dropdown-item.breakout-single {
+  opacity: 0.35;
+}
+
+.breakout-dropdown-item.breakout-single:hover {
+  opacity: 0.6;
+}
+
+.breakout-dropdown-label {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text);
+  flex-shrink: 0;
+}
+
+.breakout-dropdown-values {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+  scrollbar-width: thin;
+  flex-wrap: wrap;
+}
+
+.breakout-dropdown-val {
+  font-size: 10px;
+  padding: 1px 5px;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: all 0.1s;
+}
+
+.breakout-dropdown-val:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.breakout-dropdown-val.breakout-val-selected {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+.breakout-dropdown-val.breakout-val-unselected {
+  opacity: 0.35;
+}
+
+.breakout-dropdown-val.breakout-val-unselected:hover {
+  opacity: 0.7;
+}
+
+.breakout-dropdown-add {
+  margin-left: auto;
+  font-size: 10px !important;
+  padding: 2px 8px !important;
+}
+
 .compare-filter-group {
   display: inline-flex;
   align-items: center;

--- a/queries/cdmq/web-ui/src/index.css
+++ b/queries/cdmq/web-ui/src/index.css
@@ -62,7 +62,7 @@ body {
 .app {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 16px 24px;
+  padding: 16px 24px 120px;
 }
 
 .app-header {
@@ -1000,6 +1000,9 @@ a.run-id:hover {
 .compare-hier-row {
   display: flex;
   align-items: stretch;
+  margin-left: 60px;
+  margin-right: 30px;
+  position: relative;
 }
 
 .compare-hier-label {
@@ -1042,6 +1045,78 @@ a.run-id:hover {
 
 .compare-hier-span:last-child {
   border-radius: 0 var(--radius-sm) 0 0;
+}
+
+.compare-hier-controls {
+  position: absolute;
+  right: -30px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  width: 28px;
+  justify-content: flex-start;
+}
+
+.compare-hier-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 9px;
+  padding: 0 3px;
+  border-radius: 2px;
+  cursor: pointer;
+  line-height: 1.2;
+}
+
+.compare-hier-btn:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.compare-hier-hide:hover {
+  background: var(--danger);
+  color: #fff;
+  border-color: var(--danger);
+}
+
+.compare-hier-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  margin-left: 60px;
+  flex-wrap: wrap;
+}
+
+.compare-hier-hidden-chip {
+  font-size: 10px;
+  padding: 1px 6px;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  text-decoration: line-through;
+  cursor: pointer;
+  opacity: 0.6;
+}
+
+.compare-hier-hidden-chip:hover {
+  opacity: 1;
+  text-decoration: none;
+  border-color: var(--accent);
+}
+
+.compare-hier-add-select {
+  font-size: 10px;
+  padding: 1px 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
 }
 
 .compare-group-bar {


### PR DESCRIPTION
## Summary
- Fix group-by sort to compare per-dimension values (numeric sort for wsize, etc.)
- Fix stale sidebar data after chart recomputation (resolvedPinnedEntry)
- Store per-label breakout data for single-label cases
- Add breakout value preview dropdown with selectable value chips and pre-filtering
- New API endpoint `POST /api/v1/iterations/breakout-values` for breakout dimension values
- Add date as independent group-by column in search view with per-column sort toggle
- Move group-by controls inline with chart headers (up/down/hide, toolbar with Auto/Clear)
- Skip single-value dimensions in auto-grouping and chart headers
- Move "+ Add Metric" to bottom of charts
- Add bottom padding to prevent debug console overlap
- Fix text wrapping at natural separators only
- Update DESIGN.md documentation

## Test plan
- [ ] Numeric group-by values sort correctly (512 < 32768 < 134144)
- [ ] Click bar, add metric/breakout — sidebar still shows values
- [ ] Breakout dropdown shows value chips with counts, single-value dims dimmed
- [ ] Select specific breakout values, "Add" applies filter
- [ ] Search view: date column movable/sortable independently
- [ ] Compare view: group-by reorder/hide via chart header controls
- [ ] Auto-group excludes single-value dimensions
- [ ] Content not masked by debug console

🤖 Generated with [Claude Code](https://claude.com/claude-code)