### PR TITLE
feat: add queue and nic fields to metric_desc.names mapping

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -342,7 +342,9 @@ indexDefs['v8dev']['metric_desc']['mappings']['properties']['metric_desc'] = {
         batch: { type: 'keyword' },
         slot: { type: 'keyword' },
         blade: { type: 'keyword' },
-        rank: { type: 'keyword' }
+        rank: { type: 'keyword' },
+        queue: { type: 'keyword' },
+        nic: { type: 'keyword' }
       }
     },
     'value-format': { type: 'keyword' },


### PR DESCRIPTION
Add two new keyword fields to the metric_desc.names mapping:

- queue: for per-queue DPDK metric breakout (e.g., NIC hardware queues 0-N). Enables --breakout queue to query all queues in a single command instead of embedding the queue ID in the metric type name.

- nic: for NIC PCI address identification. Enables --breakout nic to distinguish which physical NIC a port number corresponds to across different DPDK applications on different hosts.

These fields support the tool-dpdk telemetry tool's per-queue and per-NIC metric normalization. Without these fields, OpenSearch's strict dynamic mapping rejects documents containing them.