### PR TITLE
feat: add mempool_name and function fields to metric_desc index

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -344,7 +344,9 @@ indexDefs['v8dev']['metric_desc']['mappings']['properties']['metric_desc'] = {
         blade: { type: 'keyword' },
         rank: { type: 'keyword' },
         queue: { type: 'keyword' },
-        nic: { type: 'keyword' }
+        nic: { type: 'keyword' },
+        mempool_name: { type: 'keyword' },
+        function: { type: 'keyword' }
       }
     },
     'value-format': { type: 'keyword' },


### PR DESCRIPTION
Add keyword fields required by tool-ebpf-dpdk and tool-dpdk:
- mempool_name: used by DPDK mempool telemetry metrics
- function: used by ebpf-dpdk top-function-pct metrics

Without these fields, OpenSearch rejects metric documents containing names.function or names.mempool_name during indexing.

Depends-on: https://github.com/perftool-incubator/tool-ebpf-dpdk/pull/3