### PR TITLE
Check npm install exit code before running node scripts

### DIFF
--- a/queries/cdmq/add-run.sh
+++ b/queries/cdmq/add-run.sh
@@ -19,7 +19,15 @@ if ! command -v npm >/dev/null 2>&1; then
     exit 1
 fi
 echo "Resolving cdmq dependencies..." >&2
-npm install --no-fund --no-audit 2>&1 | tail -1 >&2
+npm_output=$(npm install --no-fund --no-audit 2>&1)
+npm_rc=$?
+if [ $npm_rc -ne 0 ]; then
+    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
+    echo "$npm_output" >&2
+    popd >/dev/null
+    exit 1
+fi
+echo "$npm_output" | tail -1 >&2
 node ./add-run.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/delete-run.sh
+++ b/queries/cdmq/delete-run.sh
@@ -19,7 +19,15 @@ if ! command -v npm >/dev/null 2>&1; then
     exit 1
 fi
 echo "Resolving cdmq dependencies..." >&2
-npm install --no-fund --no-audit 2>&1 | tail -1 >&2
+npm_output=$(npm install --no-fund --no-audit 2>&1)
+npm_rc=$?
+if [ $npm_rc -ne 0 ]; then
+    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
+    echo "$npm_output" >&2
+    popd >/dev/null
+    exit 1
+fi
+echo "$npm_output" | tail -1 >&2
 node ./delete-run.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/get-metric-data.sh
+++ b/queries/cdmq/get-metric-data.sh
@@ -19,7 +19,15 @@ if ! command -v npm >/dev/null 2>&1; then
     exit 1
 fi
 echo "Resolving cdmq dependencies..." >&2
-npm install --no-fund --no-audit 2>&1 | tail -1 >&2
+npm_output=$(npm install --no-fund --no-audit 2>&1)
+npm_rc=$?
+if [ $npm_rc -ne 0 ]; then
+    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
+    echo "$npm_output" >&2
+    popd >/dev/null
+    exit 1
+fi
+echo "$npm_output" | tail -1 >&2
 node ./get-metric-data.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/get-primary-periods.sh
+++ b/queries/cdmq/get-primary-periods.sh
@@ -13,7 +13,15 @@ if ! command -v npm >/dev/null 2>&1; then
     exit 1
 fi
 echo "Resolving cdmq dependencies..." >&2
-npm install --no-fund --no-audit 2>&1 | tail -1 >&2
+npm_output=$(npm install --no-fund --no-audit 2>&1)
+npm_rc=$?
+if [ $npm_rc -ne 0 ]; then
+    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
+    echo "$npm_output" >&2
+    popd >/dev/null
+    exit 1
+fi
+echo "$npm_output" | tail -1 >&2
 node ./get-primary-periods.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/get-result-summary.sh
+++ b/queries/cdmq/get-result-summary.sh
@@ -19,7 +19,15 @@ if ! command -v npm >/dev/null 2>&1; then
     exit 1
 fi
 echo "Resolving cdmq dependencies..." >&2
-npm install --no-fund --no-audit 2>&1 | tail -1 >&2
+npm_output=$(npm install --no-fund --no-audit 2>&1)
+npm_rc=$?
+if [ $npm_rc -ne 0 ]; then
+    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
+    echo "$npm_output" >&2
+    popd >/dev/null
+    exit 1
+fi
+echo "$npm_output" | tail -1 >&2
 node ./get-result-summary.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/start-server.sh
+++ b/queries/cdmq/start-server.sh
@@ -24,7 +24,15 @@ fi
 # Install dependencies only when package-lock.json is newer than last install
 if [ ! -f "node_modules/.install-stamp" ] || [ "package-lock.json" -nt "node_modules/.install-stamp" ]; then
     echo "Installing cdmq dependencies..."
-    npm ci --no-fund --no-audit 2>&1 | tail -1
+    npm_output=$(npm ci --no-fund --no-audit 2>&1)
+    npm_rc=$?
+    if [ $npm_rc -ne 0 ]; then
+        echo "ERROR: npm ci failed (rc=$npm_rc):" >&2
+        echo "$npm_output" >&2
+        popd >/dev/null
+        exit 1
+    fi
+    echo "$npm_output" | tail -1
     touch node_modules/.install-stamp
 else
     echo "cdmq dependencies up to date"
@@ -35,7 +43,16 @@ if [ -d "web-ui" ] && [ -f "web-ui/package.json" ]; then
     pushd web-ui >/dev/null
     if [ ! -f "node_modules/.install-stamp" ] || [ "package-lock.json" -nt "node_modules/.install-stamp" ]; then
         echo "Installing web UI dependencies..."
-        npm ci --no-fund --no-audit 2>&1 | tail -1
+        npm_output=$(npm ci --no-fund --no-audit 2>&1)
+        npm_rc=$?
+        if [ $npm_rc -ne 0 ]; then
+            echo "ERROR: web UI npm ci failed (rc=$npm_rc):" >&2
+            echo "$npm_output" >&2
+            popd >/dev/null
+            popd >/dev/null
+            exit 1
+        fi
+        echo "$npm_output" | tail -1
         touch node_modules/.install-stamp
     fi
     # Rebuild if any source file is newer than the dist


### PR DESCRIPTION
## Summary
- All 5 cdmq shell wrappers (add-run, delete-run, get-metric-data, get-primary-periods, get-result-summary) and start-server.sh pipe npm install output through `tail -1` to keep logs clean, but this silently swallows errors
- When npm fails (e.g. missing packages, network issues inside containers), the script proceeds to node which crashes on missing modules with no diagnostic output
- Fix: capture npm output, check exit code, show full output only on failure; on success, still show just the summary line

## Context
Discovered via agentic-perf automated benchmark run (PERF-D095E672): fio benchmark completed successfully but OpenSearch indexing failed with "Cannot find module 'piscina'" — npm install had failed silently inside the crucible controller container.

## Test plan
- [ ] Run `add-run.sh` with valid node_modules — should show one-line summary as before
- [ ] Remove a package from node_modules, run `add-run.sh` — should show full npm error and exit non-zero
- [ ] Verify start-server.sh handles npm ci failure for both cdmq and web-ui deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)