### PR TITLE
Remove npm install from query scripts — deps managed by start-server.sh

### DIFF
--- a/queries/cdmq/add-run.sh
+++ b/queries/cdmq/add-run.sh
@@ -13,21 +13,11 @@
 
 project_dir=$(dirname `readlink -e $0`)
 pushd "$project_dir" >/dev/null
-if ! command -v npm >/dev/null 2>&1; then
-    echo "Error: npm is not installed. Please install Node.js and npm." >&2
+if [ ! -d node_modules ]; then
+    echo "Error: node_modules not found. Run start-server.sh or 'npm install' in $project_dir first." >&2
     popd >/dev/null
     exit 1
 fi
-echo "Resolving cdmq dependencies..." >&2
-npm_output=$(npm install --no-fund --no-audit 2>&1)
-npm_rc=$?
-if [ $npm_rc -ne 0 ]; then
-    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
-    echo "$npm_output" >&2
-    popd >/dev/null
-    exit 1
-fi
-echo "$npm_output" | tail -1 >&2
 node ./add-run.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/delete-run.sh
+++ b/queries/cdmq/delete-run.sh
@@ -13,21 +13,11 @@
 
 project_dir=$(dirname `readlink -e $0`)
 pushd "$project_dir" >/dev/null
-if ! command -v npm >/dev/null 2>&1; then
-    echo "Error: npm is not installed. Please install Node.js and npm." >&2
+if [ ! -d node_modules ]; then
+    echo "Error: node_modules not found. Run start-server.sh or 'npm install' in $project_dir first." >&2
     popd >/dev/null
     exit 1
 fi
-echo "Resolving cdmq dependencies..." >&2
-npm_output=$(npm install --no-fund --no-audit 2>&1)
-npm_rc=$?
-if [ $npm_rc -ne 0 ]; then
-    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
-    echo "$npm_output" >&2
-    popd >/dev/null
-    exit 1
-fi
-echo "$npm_output" | tail -1 >&2
 node ./delete-run.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/get-metric-data.sh
+++ b/queries/cdmq/get-metric-data.sh
@@ -13,21 +13,11 @@
 
 project_dir=$(dirname `readlink -e $0`)
 pushd "$project_dir" >/dev/null
-if ! command -v npm >/dev/null 2>&1; then
-    echo "Error: npm is not installed. Please install Node.js and npm." >&2
+if [ ! -d node_modules ]; then
+    echo "Error: node_modules not found. Run start-server.sh or 'npm install' in $project_dir first." >&2
     popd >/dev/null
     exit 1
 fi
-echo "Resolving cdmq dependencies..." >&2
-npm_output=$(npm install --no-fund --no-audit 2>&1)
-npm_rc=$?
-if [ $npm_rc -ne 0 ]; then
-    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
-    echo "$npm_output" >&2
-    popd >/dev/null
-    exit 1
-fi
-echo "$npm_output" | tail -1 >&2
 node ./get-metric-data.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/get-primary-periods.sh
+++ b/queries/cdmq/get-primary-periods.sh
@@ -7,21 +7,11 @@
 
 project_dir=$(dirname `readlink -e $0`)
 pushd "$project_dir" >/dev/null
-if ! command -v npm >/dev/null 2>&1; then
-    echo "Error: npm is not installed. Please install Node.js and npm." >&2
+if [ ! -d node_modules ]; then
+    echo "Error: node_modules not found. Run start-server.sh or 'npm install' in $project_dir first." >&2
     popd >/dev/null
     exit 1
 fi
-echo "Resolving cdmq dependencies..." >&2
-npm_output=$(npm install --no-fund --no-audit 2>&1)
-npm_rc=$?
-if [ $npm_rc -ne 0 ]; then
-    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
-    echo "$npm_output" >&2
-    popd >/dev/null
-    exit 1
-fi
-echo "$npm_output" | tail -1 >&2
 node ./get-primary-periods.js "$@"
 rc=$?
 popd >/dev/null

--- a/queries/cdmq/get-result-summary.sh
+++ b/queries/cdmq/get-result-summary.sh
@@ -13,21 +13,11 @@
 
 project_dir=$(dirname `readlink -e $0`)
 pushd "$project_dir" >/dev/null
-if ! command -v npm >/dev/null 2>&1; then
-    echo "Error: npm is not installed. Please install Node.js and npm." >&2
+if [ ! -d node_modules ]; then
+    echo "Error: node_modules not found. Run start-server.sh or 'npm install' in $project_dir first." >&2
     popd >/dev/null
     exit 1
 fi
-echo "Resolving cdmq dependencies..." >&2
-npm_output=$(npm install --no-fund --no-audit 2>&1)
-npm_rc=$?
-if [ $npm_rc -ne 0 ]; then
-    echo "ERROR: npm install failed (rc=$npm_rc):" >&2
-    echo "$npm_output" >&2
-    popd >/dev/null
-    exit 1
-fi
-echo "$npm_output" | tail -1 >&2
 node ./get-result-summary.js "$@"
 rc=$?
 popd >/dev/null


### PR DESCRIPTION
## Summary
- Removes redundant `npm install` from 5 query wrapper scripts (add-run.sh, delete-run.sh, get-metric-data.sh, get-primary-periods.sh, get-result-summary.sh)
- Dependencies are already installed by `start-server.sh` which runs at CDM server startup with a stamp-file guard
- Running `npm install` inside containers with overlay fs causes `ENOTEMPTY` failures when npm tries to `rmdir` directories from lower layers
- Replaces with a simple `node_modules` existence check and clear error message

## Context
Discovered via agentic-perf automated runs (PERF-7140E67D, PERF-D095E672): fio benchmarks complete successfully but OpenSearch indexing fails because `npm install` inside the crucible controller container hits overlay fs issues (`ENOTEMPTY: directory not empty, rmdir 'node_modules/js-yaml/lib'`). This is a follow-up to PR #192 which added error reporting — this PR eliminates the root cause.

## Test plan
- [ ] Run `crucible run` with a benchmark — verify add-run.sh succeeds (node_modules present from start-server.sh)
- [ ] Verify `start-server.sh` still installs deps on first launch
- [ ] Manually remove node_modules and run add-run.sh — verify clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)