### PR TITLE
fix: 7 critical bugs in cdm.js and server.js

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -3540,7 +3540,7 @@ getMetricDataSets = async function (instance, sets, yearDotMonth) {
         }
         sets[i].end = periodRange.end;
       } else {
-        retMag = 'ERROR: end is not defined or a period was not defined';
+        retMsg = 'ERROR: end is not defined or a period was not defined';
         retCode = 2;
         return { 'data-sets': [], 'ret-code': retCode, 'ret-msg': retMsg };
       }

--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -2435,7 +2435,7 @@ getIters = async function (
       }
     });
   }
-  if (isDefined(addIterations) && addRuns != []) {
+  if (isDefined(addIterations) && addIterations != []) {
     addIterations.forEach((id) => {
       if (!allIterIds.includes(id)) {
         allIterIds.push(id);

--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -2896,7 +2896,6 @@ mgetMetricIdsFromTerms = async function (instance, termsSets, yearDotMonth) {
       ') did not match number of requests (' +
       totalReqs +
       ')';
-    retMsg = 'ERROR: mgetMetricIdsFromTerms(), terms[' + i + ']  must have either a period-id or run-id';
     retCode = 2;
     return { 'metric-id-sets': metricIdsSets, 'ret-code': retCode, 'ret-msg': retMsg };
   }

--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -2314,7 +2314,7 @@ getIters = async function (
   });
 
   if (jsonArr.length > 0) {
-    var responses = esJsonArrRequest(instance, 'tag', '/_msearch', jsonArr);
+    var responses = await esJsonArrRequest(instance, 'tag', '/_msearch', jsonArr);
     var runIds = [];
     responses.forEach((response) => {
       var theseRunIds = [];
@@ -2326,7 +2326,7 @@ getIters = async function (
     var intersectedRunIds = intersectAllArrays(runIds);
 
     if (jsonArr2.length > 0) {
-      var responses2 = esJsonArrRequest(instance, 'tag', '/_msearch', jsonArr2);
+      var responses2 = await esJsonArrRequest(instance, 'tag', '/_msearch', jsonArr2);
       responses2.forEach((response) => {
         response.hits.hits.forEach((run) => {
           if (intersectedRunIds.includes(run._source.run['run-uuid'])) {
@@ -2378,8 +2378,7 @@ getIters = async function (
 
   var iterIdsFromParam = [];
   if (jsonArr.length > 0) {
-    var resp = esJsonArrRequest(instance, 'param', '/_msearch', jsonArr);
-    var responses = JSON.parse(resp.getBody());
+    var responses = await esJsonArrRequest(instance, 'param', '/_msearch', jsonArr);
     var iterationIds = [];
     responses.forEach((response) => {
       var theseIterationIds = [];
@@ -2391,8 +2390,7 @@ getIters = async function (
     iterIdsFromParam = intersectAllArrays(iterationIds);
 
     if (jsonArr2 != '') {
-      var resp2 = esJsonArrRequest(instance, 'tag', '/_msearch', jsonArr2);
-      var responses2 = JSON.parse(resp2.getBody());
+      var responses2 = await esJsonArrRequest(instance, 'tag', '/_msearch', jsonArr2);
       responses2.forEach((response) => {
         response.hits.hits.forEach((hit) => {
           if (iterIdsFromParam.includes(hit._source.iteration['iteration-uuid'])) {

--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -3605,7 +3605,7 @@ getMetricDataSets = async function (instance, sets, yearDotMonth) {
 
   // Ensure that any breakouts are available for each set
   for (var i = 0; i < sets.length; i++) {
-    if (sets[i].breakout != 'undefined') {
+    if (isDefined(sets[i].breakout)) {
       for (var j = 0; j < sets[i].breakout.length; j++) {
         var breakout = parseBreakoutEntry(sets[i].breakout[j]).name;
         if (!setBreakouts[i].includes(breakout)) {

--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -1029,7 +1029,7 @@ mSearch = async function (instance, index, yearDotMonth, termKeys, values, sourc
                 console.log(
                   'WARNING: the requested source for this query [' + source + '] does not exist in the returned data:\n'
                 );
-                console.log(JSON.stringify(obj.null, 2));
+                console.log(JSON.stringify(obj, null, 2));
                 return;
               }
               obj = obj[thisObj];

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -1637,7 +1637,7 @@ app.post('/api/v1/metric-data', async (req, res) => {
         error: resp['ret-msg']
       });
     }
-    metric_data = resp['data-sets'][0];
+    var metric_data = resp['data-sets'][0];
 
     var labelCount = metric_data && metric_data.values ? Object.keys(metric_data.values).length : 0;
     var elapsed = Date.now() - reqStart;


### PR DESCRIPTION
## Summary

Seven critical bugs in the CDM query engine, each as a separate commit:

- **Missing `await` on 4 `esJsonArrRequest()` calls** — `.forEach()` on a Promise silently fails, tag/param filters in `getIters()` produce no results
- **`JSON.stringify(obj.null, 2)` wrong arg order** — logs `undefined` instead of the object that failed source resolution
- **`retMag` typo** — error message assigned to throwaway variable, caller gets empty `ret-msg`
- **`addRuns` checked instead of `addIterations`** — `--add-iterations` only works when `--add-runs` is also non-empty
- **Detailed error immediately overwritten** — response/request count mismatch error replaced by unrelated generic message
- **`!= 'undefined'` string comparison** — compares against literal string instead of using `isDefined()`, causes TypeError when breakout is actually undefined
- **Implicit global `metric_data` in server.js** — missing `var` creates race condition on concurrent `/api/v1/metric-data` requests

Closes #194

## Test plan
- [ ] Syntax verified: `node --check` passes on both files
- [ ] Review each commit individually for correctness
- [ ] Run CDM query server and verify metric-data endpoint returns correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)