### PR TITLE
fix: undefined vars, regex bugs, sourceType crash, and typos

### DIFF
--- a/queries/cdmq/add-run-worker.js
+++ b/queries/cdmq/add-run-worker.js
@@ -76,7 +76,7 @@ module.exports = async ({ instance, filePath, docTypes, mode }) => {
         var action = JSON.parse(jsonArr[k - 1]);
         var doc = JSON.parse(jsonArr[k]);
       } catch (jsonError) {
-        console.log('Could not porse: [' + jsonArr[k] + ']');
+        console.log('Could not parse: [' + jsonArr[k] + ']');
         continue;
       }
       let runId = doc['run']['run-uuid'];

--- a/queries/cdmq/add-run.js
+++ b/queries/cdmq/add-run.js
@@ -160,8 +160,8 @@ async function main() {
         instance['ver'] = cdmVer;
       } else {
         console.log('ERROR: there was not exactly one CDM version found in the data to be indexed:\n');
-        console.log(Object.keys(info['indices']));
-        console.log('info\n' + JSON.stringify(info['indices'], null, 2));
+        console.log(Object.keys(info['runIds'][runId]['indices']));
+        console.log('info\n' + JSON.stringify(info['runIds'][runId]['indices'], null, 2));
         process.exit(1);
       }
       if (info.docFields) {

--- a/queries/cdmq/add-run.js
+++ b/queries/cdmq/add-run.js
@@ -29,7 +29,7 @@ function save_ver(ver) {
     console.log('You must specify a --host before a --ver');
     process.exit(1);
   }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
+  if (/^v[789]dev$/.exec(ver)) {
     instances[instances.length - 1]['ver'] = ver;
   } else {
     console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);

--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -368,12 +368,12 @@ indexDefs['v9dev']['metric_desc'] = deepClone(indexDefs['v8dev']['metric_desc'])
 //
 // For example, for mpstat:
 // <doc1>
-// mestric_desc-uuid:  same uuid in metric_desc doc that has source: mpstat, type: Busy-CPU
+// metric_desc-uuid:  same uuid in metric_desc doc that has source: mpstat, type: Busy-CPU
 // name: cpu
 // definition: A logical CPU ID, as found in lscpu, /proc/cpu, and /sys/devices/system/cpu/cpu*
 //
 // <doc2>
-// mestric_desc-uuid:  same uuid in metric_desc doc that has source: mpstat, type: Busy-CPU
+// metric_desc-uuid:  same uuid in metric_desc doc that has source: mpstat, type: Busy-CPU
 // name: package
 // definition: The ID of a physical grouping of CPU cores on a single chip.  Often the same as a NUMA node ID.
 indexDefs['v9dev']['metric_def'] = deepClone(indexDefs['v9dev']['period']);
@@ -1014,7 +1014,7 @@ mSearch = async function (instance, index, yearDotMonth, termKeys, values, sourc
               i +
               '].hits.hits.length (' +
               responses[i].hits.hits.length +
-              ') are not equal, which means the retured data is probably incomplete'
+              ') are not equal, which means the returned data is probably incomplete'
           );
         }
         var ids = [];
@@ -2221,7 +2221,7 @@ reportIters = function (iterTree, indent, count) {
       return count;
     }
   } else {
-    // We should be at a leaf of the tree.  Anything in breakout[] should be params or tags which were reqsuested to not break-out
+    // We should be at a leaf of the tree.  Anything in breakout[] should be params or tags which were requested to not break-out
     const sorted = iterTree.iterations.sort((a, b) =>
       a.labels.localeCompare(b.labels, undefined, {
         numeric: true,
@@ -2246,7 +2246,7 @@ reportIters = function (iterTree, indent, count) {
 };
 
 // --------------------------------------------------------------------------------------------------------------
-// getIters(): filter and group interations, typically for generating comparisons (clustered bar graphs)
+// getIters(): filter and group iterations, typically for generating comparisons (clustered bar graphs)
 getIters = async function (
   instance,
   filterByAge,
@@ -3324,7 +3324,7 @@ calcAvg = function (thisBegin, thisEnd, responses, jsonArrIdx, jsonArrTracker, n
           jsonArrIdx / 2 +
           '].hits.hits.length (' +
           responses[jsonArrIdx / 2].hits.hits.length +
-          ') are not equal, which means the retured data is probably incomplete'
+          ') are not equal, which means the returned data is probably incomplete'
       );
     }
     responses[jsonArrIdx / 2].hits.hits.forEach((element) => {
@@ -3577,7 +3577,7 @@ getMetricDataSets = async function (instance, sets, yearDotMonth) {
   for (var i = 0; i < sets.length; i++) {
     if (!metricSources[i].includes(sets[i].source)) {
       retMsg = 'ERROR: the metric-source [' + sets[i].source + '] was not found in run [' + sets[i].run + ']\n';
-      retMsg += 'The available soucres for this run are: ' + metricSources[i];
+      retMsg += 'The available sources for this run are: ' + metricSources[i];
       retCode = 1;
       return { 'ret-code': retCode, 'ret-msg': retMsg };
     }

--- a/queries/cdmq/create-index.js
+++ b/queries/cdmq/create-index.js
@@ -50,7 +50,7 @@ async function main() {
   if (program.index) {
     cdm.checkCreateIndex(instances[instances.length - 1], program.index);
   } else {
-    console.log('--index <index-nane> is required');
+    console.log('--index <index-name> is required');
   }
   console.log('create-index is complete');
 }

--- a/queries/cdmq/create-index.js
+++ b/queries/cdmq/create-index.js
@@ -24,7 +24,7 @@ function save_ver(ver) {
     console.log('You must specify a --host before a --ver');
     process.exit(1);
   }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
+  if (/^v[789]dev$/.exec(ver)) {
     instances[instances.length - 1]['ver'] = ver;
   } else {
     console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);

--- a/queries/cdmq/delete-run.js
+++ b/queries/cdmq/delete-run.js
@@ -83,7 +83,7 @@ async function main() {
     cdm.deleteDocs(instance, allDocTypes, q, yearDotMonth);
     const numDocTypes = await cdm.waitForDeletedDocs(instance, program.run, allDocTypes, yearDotMonth);
     if (numDocTypes > 0) {
-      console.log('Warning: could not delete all documents for ' + docTypes + ' with ' + numAttempts);
+      console.log('Warning: could not delete all documents for ' + numDocTypes + ' remaining doc type(s)');
       console.log(
         'These documents may continue to be deleted in the background.  To check on the status, run this utility again'
       );

--- a/queries/cdmq/delete-run.js
+++ b/queries/cdmq/delete-run.js
@@ -23,7 +23,7 @@ function save_ver(ver) {
     console.log('You must specify a --host before a --ver');
     process.exit(1);
   }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
+  if (/^v[789]dev$/.exec(ver)) {
     instances[instances.length - 1]['ver'] = ver;
   } else {
     console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);

--- a/queries/cdmq/get-instances-info.js
+++ b/queries/cdmq/get-instances-info.js
@@ -24,7 +24,7 @@ function save_ver(ver) {
     console.log('You must specify a --host before a --ver');
     process.exit(1);
   }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
+  if (/^v[789]dev$/.exec(ver)) {
     instances[instances.length - 1]['ver'] = ver;
   } else {
     console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);

--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -148,7 +148,7 @@ async function main() {
     )
     .option(
       '--end [uint]',
-      "[optional] Timestamp in epochtime_ms, within the period's begin-end time range, where the calculation of the metric will end.  If no --begin and no -end are provided, a begin and end timestamp will be derived based on when all metrics of this source and type have data present.  If --begin is before or --end is after these derived begin/end vaules, they will be adjusted (--begin is increased and/or --end is decreased) to fit within this range."
+      "[optional] Timestamp in epochtime_ms, within the period's begin-end time range, where the calculation of the metric will end.  If no --begin and no -end are provided, a begin and end timestamp will be derived based on when all metrics of this source and type have data present.  If --begin is before or --end is after these derived begin/end values, they will be adjusted (--begin is increased and/or --end is decreased) to fit within this range."
     )
     .option('--resolution [uint]', '[optional] The number of datapoints to produce in a data-series', 1)
     .option(
@@ -159,7 +159,7 @@ async function main() {
     )
     .option(
       '--filter <gt|ge|lt|le:value>',
-      '[optional] Filter out (do not output) metrics which do not pass the conditional.  gt=greather-than, ge=greater-than-or-equal, lt=less-than, le=less-than-or-equal'
+      '[optional] Filter out (do not output) metrics which do not pass the conditional.  gt=greater-than, ge=greater-than-or-equal, lt=less-than, le=less-than-or-equal'
     )
     .option('--output-format <json|table|csv>', 'table')
     .option(

--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -105,7 +105,7 @@ function save_ver(ver) {
     console.log('You must specify a --host before a --ver');
     process.exit(1);
   }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
+  if (/^v[789]dev$/.exec(ver)) {
     program.instances[program.instances.length - 1]['ver'] = ver;
   } else {
     console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);

--- a/queries/cdmq/get-metric-data.js
+++ b/queries/cdmq/get-metric-data.js
@@ -163,8 +163,8 @@ async function main() {
     )
     .option('--output-format <json|table|csv>', 'table')
     .option(
-      '--date-format <default|eopch_ms>',
-      '[optional] otuput date/time in DD-MM-YYYY HH:MM:SS (the default) or epoch time in milliseconds',
+      '--date-format <default|epoch_ms>',
+      '[optional] output date/time in DD-MM-YYYY HH:MM:SS (the default) or epoch time in milliseconds',
       'default'
     )
     .option(

--- a/queries/cdmq/get-primary-periods.js
+++ b/queries/cdmq/get-primary-periods.js
@@ -30,7 +30,7 @@ function save_ver(ver) {
     console.log('You must specify a --host before a --ver');
     process.exit(1);
   }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
+  if (/^v[789]dev$/.exec(ver)) {
     instances[instances.length - 1]['ver'] = ver;
   } else {
     console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);

--- a/queries/cdmq/get-result-summary.js
+++ b/queries/cdmq/get-result-summary.js
@@ -523,6 +523,8 @@ async function main() {
       thisIteration['results'] = [];
       for (var k = 0; k < primaryMetrics.length; k++) {
         var sourceType = primaryMetrics[k].split('::');
+        var source = sourceType.length == 2 ? sourceType[0] : benchmarks[0];
+        var type = sourceType.length == 2 ? sourceType[1] : primaryMetrics[k];
         var thisValue = {};
         if (allBenchMsampleCount[k] > 0) {
           var mean = allBenchMsampleTotal[k] / allBenchMsampleCount[k];
@@ -535,9 +537,9 @@ async function main() {
           var mstddevpct = (100 * mstddev) / mean;
           logOutput(
             '            result: (' +
-              sourceType[0] +
+              source +
               '::' +
-              sourceType[1] +
+              type +
               ') samples:' +
               allBenchMsampleFixedList[k] +
               ' mean: ' +

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -67,7 +67,7 @@ function save_ver(ver) {
     console.log('You must specify a --host before a --ver');
     process.exit(1);
   }
-  if (/^v[7|8|9]dev$/.exec(ver)) {
+  if (/^v[789]dev$/.exec(ver)) {
     instances[instances.length - 1]['ver'] = ver;
   } else {
     console.log('The version must be v7dev, v8dev, or v9dev, not: ' + ver);


### PR DESCRIPTION
## Summary
- **delete-run.js**: Fix undefined `docTypes` and `numAttempts` in warning message — use `numDocTypes`
- **add-run.js**: Fix wrong property path `info['indices']` — should be `info['runIds'][runId]['indices']`
- **get-result-summary.js**: Handle metric names without `::` separator — `sourceType[1]` was undefined
- **get-metric-data.js**: Fix `eopch_ms` → `epoch_ms` and `otuput` → `output` typos in help text
- **7 files**: Fix regex `[7|8|9]` → `[789]` in CDM version check — was also matching literal pipe
- **4 files**: Fix typos: `index-nane`, `porse`, `vaules`, `greather`, `mestric_desc-uuid`, `retured`, `reqsuested`, `interations`, `soucres`

Closes #195

## Test plan
- [ ] CI passes (prettier check)
- [ ] `node queries/cdmq/delete-run.js --help` — no syntax errors
- [ ] `node queries/cdmq/add-run.js --help` — no syntax errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)