### PR TITLE
feat: add fwd_interface and rev_interface to metric_desc names

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -275,6 +275,8 @@ indexDefs['v8dev']['metric_desc']['mappings']['properties']['metric_desc'] = {
         port: { type: 'keyword' },
         tx_port: { type: 'keyword' },
         rx_port: { type: 'keyword' },
+        fwd_interface: { type: 'keyword' },
+        rev_interface: { type: 'keyword' },
         port_pair: { type: 'keyword' },
         status: { type: 'keyword' },
         error: { type: 'keyword' },


### PR DESCRIPTION
## Summary

- Add `fwd_interface` and `rev_interface` keyword fields to the `metric_desc.names` index definition
- Enables ptp-latency hardware timestamped latency metrics in bench-trafficgen (PR#126) to record the kernel interface pair used for measurement
- Existing indices are auto-updated via `updateIndexMappings()` (commit 69564b9)

## Related

- bench-trafficgen PR#126 (ptp-latency post-processing uses these fields)

## Test plan

- [x] Integration tested: `crucible run` with ptp-latency enabled, "Document field validation passed", indexing succeeded with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)