### PR TITLE
docs: update CLAUDE.md for v10dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,10 @@ Defines a unified data model for storing and querying performance test data in O
 Supporting document types: `param`, `tag`, `config_*`
 
 ## Versioning
-- Versions tracked as git branches and in `VERSION` file (currently `v8dev`)
-- `cdm.js` exports `supportedCdmVersions` array: `['v7dev', 'v8dev', 'v9dev']`
-- Index naming pattern: `cdm{VERSION}-{DOCTYPE}*` (e.g., `cdmv8dev-metric_data*`)
+- Versions tracked as git branches and in `VERSION` file (currently `v10dev`)
+- `cdm.js` exports `supportedCdmVersions` array: `['v7dev', 'v8dev', 'v9dev', 'v10dev']`
+- Index naming pattern: `cdm{VERSION}-{DOCTYPE}*` (e.g., `cdmv10dev-metric_data*`)
+- v10dev's key addition is `default-aggregation` — a per-metric field on `metric_desc` (`sum`/`avg`/`max`/`min`) telling query-time aggregation how to combine values across breakout dimensions, instead of always duration-weighted summing
 
 ## Templates (`templates/`)
 - `.base` files define index mappings for each document type


### PR DESCRIPTION
## Summary
- Update CLAUDE.md's Versioning section: current version is `v10dev` (was stale at `v8dev`)
- Include `v9dev` and `v10dev` in the supported versions list
- Note `default-aggregation` as the key v10dev addition

Addresses [PERFNFV-466](https://redhat.atlassian.net/browse/PERFNFV-466) from the architecture review — CLAUDE.md had drifted from the actual `VERSION` file and `cdm.js`'s `supportedCdmVersions`.

## Test plan
- [x] Diffed against `VERSION` file and `cdm.js` `docTypes`/`supportedCdmVersions` to confirm accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)