### PR TITLE
feat: add partial and dropped-engines fields to run doc mapping

### DIFF
--- a/queries/cdmq/cdm.js
+++ b/queries/cdmq/cdm.js
@@ -157,6 +157,12 @@ indexDefs['v8dev']['run'] = {
   }
 };
 indexDefs['v9dev']['run'] = deepClone(indexDefs['v8dev']['run']);
+indexDefs['v9dev']['run']['mappings']['properties']['run']['properties']['partial'] = {
+  type: 'boolean'
+};
+indexDefs['v9dev']['run']['mappings']['properties']['run']['properties']['dropped-engines'] = {
+  type: 'keyword'
+};
 
 // both tag and iteration start with the run mapping
 indexDefs['v8dev']['tag'] = deepClone(indexDefs['v8dev']['run']);


### PR DESCRIPTION
## Summary
- Adds `partial` (boolean) and `dropped-engines` (keyword) fields to the `run` doctype mapping (v9dev, inherited by v10dev)
- Supports an upcoming rickshaw change (PERFNFV-464) that records when a benchmark run loses engines mid-run (roadblock timeout/crash) so results can be flagged and queried as partial

## Context
Architecture review (PERFNFV-464) found that a crashed/dropped engine mid-run currently has no visibility beyond an in-memory log line — the run "succeeds" with fewer engines and nothing records that fact. Rickshaw will start emitting these fields on the run document; this PR adds the mapping first since the `run` index uses `dynamic: "strict"` — emitting the fields before the mapping exists would cause OpenSearch to reject the documents (same class of issue found in PERFNFV-455).

This should merge before the rickshaw PR that emits these fields, to avoid indexing rejections on the run document.

## Test plan
- [x] `node -c queries/cdmq/cdm.js` — syntax check passes
- [x] Verified via `require()` that both v9dev and v10dev `run` mappings include the new `partial`/`dropped-engines` properties
- [x] End-to-end: ran a live benchmark against this OpenSearch instance and confirmed the `run` doctype document indexes successfully with `partial: false, dropped-engines: []` on the happy path, and `partial: true, dropped-engines: ["client-1"]` when an engine was killed mid-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)