### PR TITLE
feat: surface partial-run status in get-result-summary (PERFNFV-464)

### DIFF
--- a/queries/cdmq/get-result-summary.js
+++ b/queries/cdmq/get-result-summary.js
@@ -202,6 +202,23 @@ async function main() {
     thisRun['run-id'] = runId;
     thisRun['iterations'] = [];
 
+    // Fetch partial-run status
+    var partialResp;
+    try {
+      partialResp = await apiGet(baseUrl, runPrefix + '/partial-status');
+    } catch (error) {
+      console.error('Error fetching partial-run status for run ' + runId + ': ' + error.message);
+      process.exit(1);
+    }
+    thisRun['partial'] = partialResp.partial;
+    thisRun['dropped-engines'] = partialResp['dropped-engines'];
+    if (partialResp.partial) {
+      logOutput(
+        '  partial: yes (' + partialResp['dropped-engines'].length + ' engine(s) dropped)',
+        program.outputFormat
+      );
+    }
+
     // Fetch tags
     var tagsResp;
     try {

--- a/queries/cdmq/server.js
+++ b/queries/cdmq/server.js
@@ -380,6 +380,27 @@ app.get('/api/v1/run/:id/benchmark', resolveRun, async (req, res) => {
 });
 
 // --------------------------------------------------------------------------------------------------------------
+// GET /api/v1/run/:id/partial-status — get partial-run/dropped-engines status for a run
+// --------------------------------------------------------------------------------------------------------------
+app.get('/api/v1/run/:id/partial-status', resolveRun, async (req, res) => {
+  try {
+    const { instance, yearDotMonth, runId } = req.cdm;
+    var runDataArr = await cdm.getRunData(instance, runId, yearDotMonth);
+    var runData = (runDataArr && runDataArr[0]) || {};
+    var partial = (runData.run && runData.run.partial) || false;
+    var droppedEngines = (runData.run && runData.run['dropped-engines']) || [];
+    serverLog('[' + Date.now() + '] GET /api/v1/run/' + runId + '/partial-status returned partial=' + partial);
+    res.json({ partial: partial, 'dropped-engines': droppedEngines });
+  } catch (error) {
+    serverError('Error in GET /api/v1/run/:id/partial-status:', error);
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      error: 'Failed to get partial-run status: ' + error.message
+    });
+  }
+});
+
+// --------------------------------------------------------------------------------------------------------------
 // GET /api/v1/run/:id/iterations — get iteration UUIDs for a run
 // --------------------------------------------------------------------------------------------------------------
 app.get('/api/v1/run/:id/iterations', resolveRun, async (req, res) => {


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/run/:id/partial-status`, mirroring the existing `/benchmark` endpoint, reading `run.partial`/`run.dropped-engines` (already added to the v9dev+ run mapping in PR#204) via the existing `cdm.getRunData()` helper. Gracefully defaults to `partial: false, dropped-engines: []` for older CDM versions that predate these fields.
- `get-result-summary.js` fetches this alongside `tags`/`benchmark` and prints `partial: yes (N engine(s) dropped)` when applicable — matching the wording `bin/result-processor.py` already uses for `crucible ls` in the crucible repo.
- Closes the gap flagged in [crucible PR#652](https://github.com/perftool-incubator/crucible/pull/652)'s review: the doc claimed both `crucible ls` and `crucible get result` surface partial-run status, but only `crucible ls` actually did until now.

## Test plan
- [x] `crucible get result` path (`partial: false`) verified against a real indexed run
- [x] `partial: true` path verified against a synthetic run+iteration doc pair inserted directly into OpenSearch (deleted afterward) — a genuinely-indexed partial run is hard to produce naturally, since a dropped engine tends to break later pipeline steps before indexing completes
- [x] `node_modules/.bin/prettier --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)